### PR TITLE
feat: render Quarto to PDF inside Obsidian (0.1.0-rc.1, BRAT beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ The main difference between this plugin and these other plugins is that this plu
 
 ## Version History
 
+### 0.1.0-rc.1 (beta — BRAT only)
+- Added **Render Quarto to PDF** command and ribbon icon. Runs `quarto render <file> --to pdf` on the active `.qmd` file.
+- Added **"Open Compiled PDF in Obsidian"** setting toggle. When enabled, the rendered PDF opens inside Obsidian using the built-in PDF viewer.
+- PDF opens in a vertical split to the right of the source `.qmd`, so the source tab is no longer replaced.
+- Re-running the render reuses the existing PDF tab (reloads the file in place) instead of stacking new tabs.
+- Command exposes a `file-output` icon, so plugins like **Commander** can pin it to the toolbar.
+
 ### 0.0.3
 - Added an option to run Quarto preview for the current `qmd` file.
 
@@ -35,8 +42,22 @@ The main difference between this plugin and these other plugins is that this plu
 - [ ] Recognize `{language}` for code block syntax highlighting.
 - [ ] Add CSS support for callout blocks.
 - [ ] Enable the creation of new QMD files.
-- [ ] Add a render command.
+- [x] Add a render command. *(0.1.0-rc.1 — render to PDF, open inside Obsidian.)*
 
+
+---
+
+## Rendering to PDF (beta)
+
+Available from **0.1.0-rc.1** via BRAT.
+
+- Command: **Render Quarto to PDF** (palette + ribbon icon `file-output`). Runs `quarto render <file> --to pdf` on the active `.qmd`.
+- Setting **Open Compiled PDF in Obsidian** (off by default):
+  - **Off** — render finishes, notice shows the PDF path. Open it however you want.
+  - **On** — rendered PDF opens in a vertical split on the right via Obsidian's built-in PDF viewer. Source tab keeps focus.
+- Re-running the render reuses the existing PDF tab — no tab stacking.
+- The `.qmd` source must live inside the vault (the rendered `.pdf` lands next to it; Obsidian only opens vault files).
+- Custom `output-dir` in `_quarto.yml` is not yet handled — the plugin looks for `<basename>.pdf` next to the source.
 
 ---
 
@@ -76,8 +97,19 @@ This plugin requires Obsidian **v0.10.12** or later to work properly, as the nec
 
 ### From Within Obsidian
 
-The plugin is available in Obsidian's community plugin list.  
-For beta releases, you can use the [BRAT plugin](https://github.com/TfTHacker/obsidian42-brat).
+The plugin is available in Obsidian's community plugin list. The community-store version always tracks the latest **stable** release (currently `0.0.3`).
+
+### Beta releases via BRAT
+
+Pre-release versions (`-rc.x`, `-beta.x`) are **only** distributed through [BRAT](https://github.com/TfTHacker/obsidian42-brat). The community plugin store will not show them.
+
+1. Install **Obsidian42 - BRAT** from the community plugins list.
+2. Open BRAT settings → **Add Beta plugin with frozen version** is *not* needed — use **Add Beta plugin**.
+3. Enter the repo: `danieltomasz/qmd-as-md-obsidian`.
+4. BRAT reads `manifest-beta.json` from the repo and installs the latest pre-release tag (e.g. `0.1.0-rc.1`).
+5. Enable the plugin in **Settings → Community plugins**.
+
+To switch back to stable, remove the plugin from BRAT and reinstall from the community store.
 
 ### From GitHub
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,0 +1,10 @@
+{
+  "id": "qmd-as-md-obsidian",
+  "version": "0.1.0-rc.1",
+  "description": "This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.",
+  "name": "qmd as md",
+  "author": "Daniel Borek",
+  "authorUrl": "https://github.com/danieltomasz",
+  "isDesktopOnly": false,
+  "minAppVersion": "0.10.12"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qmd-as-md-obsidian",
-  "version": "0.0.3",
+  "version": "0.1.0-rc.1",
   "description": "Edit and preview QMD files in Obsidian with Quarto support",
   "main": "main.js",
   "type": "module",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,14 +14,16 @@ interface QmdPluginSettings {
   quartoPath: string;
   enableQmdLinking: boolean;
   quartoTypst: string;
-  emitCompilationLogs: boolean; // New setting
+  emitCompilationLogs: boolean;
+  openPdfInObsidian: boolean;
 }
 
 const DEFAULT_SETTINGS: QmdPluginSettings = {
   quartoPath: 'quarto',
   enableQmdLinking: true,
   quartoTypst: '',
-  emitCompilationLogs: true, // Default is to emit logs
+  emitCompilationLogs: true,
+  openPdfInObsidian: false,
 };
 
 export default class QmdAsMdPlugin extends Plugin {
@@ -65,6 +67,29 @@ export default class QmdAsMdPlugin extends Plugin {
           }
         },
         hotkeys: [{ modifiers: ['Ctrl', 'Shift'], key: 'p' }],
+      });
+
+      this.addRibbonIcon('file-output', 'Render Quarto to PDF', async () => {
+        const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (activeView?.file && this.isQuartoFile(activeView.file)) {
+          await this.renderPdf(activeView.file);
+        } else {
+          new Notice('Current file is not a Quarto document');
+        }
+      });
+
+      this.addCommand({
+        id: 'render-quarto-pdf',
+        name: 'Render Quarto to PDF',
+        icon: 'file-output',
+        callback: async () => {
+          const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+          if (activeView?.file && this.isQuartoFile(activeView.file)) {
+            await this.renderPdf(activeView.file);
+          } else {
+            new Notice('Current file is not a Quarto document');
+          }
+        },
       });
 
       console.log('Commands added');
@@ -209,6 +234,86 @@ export default class QmdAsMdPlugin extends Plugin {
       new Notice('All Quarto previews stopped');
     }
   }
+
+  async renderPdf(file: TFile) {
+    try {
+      const abstractFile = this.app.vault.getAbstractFileByPath(file.path);
+      if (!abstractFile || !(abstractFile instanceof TFile)) {
+        new Notice(`File ${file.path} not found`);
+        return;
+      }
+
+      const filePath = (this.app.vault.adapter as any).getFullPath(abstractFile.path);
+      const workingDir = path.dirname(filePath);
+
+      const envVars: NodeJS.ProcessEnv = { ...process.env };
+      if (this.settings.quartoTypst.trim()) {
+        envVars.QUARTO_TYPST = this.settings.quartoTypst.trim();
+      }
+
+      new Notice('Rendering Quarto to PDF...');
+
+      const quartoProcess = spawn(
+        this.settings.quartoPath,
+        ['render', filePath, '--to', 'pdf'],
+        { cwd: workingDir, env: envVars }
+      );
+
+      quartoProcess.stdout?.on('data', (data: Buffer) => {
+        if (this.settings.emitCompilationLogs) {
+          console.log(`Quarto Render Output: ${data.toString()}`);
+        }
+      });
+
+      quartoProcess.stderr?.on('data', (data: Buffer) => {
+        if (this.settings.emitCompilationLogs) {
+          console.error(`Quarto Render Error: ${data.toString()}`);
+        }
+      });
+
+      quartoProcess.on('close', async (code: number | null) => {
+        if (code !== 0) {
+          new Notice(`Quarto render failed (exit ${code}). Check console.`);
+          return;
+        }
+
+        const pdfVaultPath = file.path.replace(/\.qmd$/i, '.pdf');
+        const pdfTFile = await this.waitForVaultFile(pdfVaultPath);
+
+        if (this.settings.openPdfInObsidian && pdfTFile) {
+          const existing = this.app.workspace
+            .getLeavesOfType('pdf')
+            .find((l) => (l.view as any)?.file?.path === pdfTFile.path);
+
+          let leaf;
+          if (existing) {
+            leaf = existing;
+            await leaf.openFile(pdfTFile, { active: false });
+          } else {
+            leaf = this.app.workspace.getLeaf('split', 'vertical');
+            await leaf.openFile(pdfTFile, { active: false });
+          }
+          this.app.workspace.revealLeaf(leaf);
+          new Notice(`Opened ${pdfVaultPath}`);
+        } else {
+          new Notice(`PDF rendered: ${pdfVaultPath}`);
+        }
+      });
+    } catch (error) {
+      console.error('Failed to render Quarto PDF:', error);
+      new Notice('Failed to render Quarto PDF');
+    }
+  }
+
+  async waitForVaultFile(vaultPath: string, timeoutMs = 5000): Promise<TFile | null> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const f = this.app.vault.getAbstractFileByPath(vaultPath);
+      if (f instanceof TFile) return f;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    return null;
+  }
 }
 
 class QmdSettingTab extends PluginSettingTab {
@@ -282,6 +387,21 @@ class QmdSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             console.log(`Emit Compilation Logs set to: ${value}`);
             this.plugin.settings.emitCompilationLogs = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Open Compiled PDF in Obsidian')
+      .setDesc(
+        'When rendering to PDF, open the resulting file inside Obsidian using the built-in PDF viewer. The .qmd source must live in the vault so the rendered PDF is accessible.'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.openPdfInObsidian)
+          .onChange(async (value) => {
+            console.log(`Open PDF in Obsidian set to: ${value}`);
+            this.plugin.settings.openPdfInObsidian = value;
             await this.plugin.saveSettings();
           })
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
   PluginSettingTab,
   App,
   Setting,
+  FileSystemAdapter,
 } from 'obsidian';
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
@@ -44,12 +45,10 @@ export default class QmdAsMdPlugin extends Plugin {
       console.log('Settings tab added successfully');
 
       this.addRibbonIcon('eye', 'Toggle Quarto Preview', async () => {
-        const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (activeView?.file && this.isQuartoFile(activeView.file)) {
-          console.log(`Toggling preview for: ${activeView.file.path}`);
-          await this.togglePreview(activeView.file);
-        } else {
-          new Notice('Current file is not a Quarto document');
+        const file = this.getActiveQuartoFile();
+        if (file) {
+          console.log(`Toggling preview for: ${file.path}`);
+          await this.togglePreview(file);
         }
       });
       console.log('Ribbon icon added');
@@ -58,24 +57,18 @@ export default class QmdAsMdPlugin extends Plugin {
         id: 'toggle-quarto-preview',
         name: 'Toggle Quarto Preview',
         callback: async () => {
-          const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-          if (activeView?.file && this.isQuartoFile(activeView.file)) {
-            console.log(`Command: Toggling preview for ${activeView.file.path}`);
-            await this.togglePreview(activeView.file);
-          } else {
-            new Notice('Current file is not a Quarto document');
+          const file = this.getActiveQuartoFile();
+          if (file) {
+            console.log(`Command: Toggling preview for ${file.path}`);
+            await this.togglePreview(file);
           }
         },
         hotkeys: [{ modifiers: ['Ctrl', 'Shift'], key: 'p' }],
       });
 
       this.addRibbonIcon('file-output', 'Render Quarto to PDF', async () => {
-        const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (activeView?.file && this.isQuartoFile(activeView.file)) {
-          await this.renderPdf(activeView.file);
-        } else {
-          new Notice('Current file is not a Quarto document');
-        }
+        const file = this.getActiveQuartoFile();
+        if (file) await this.renderPdf(file);
       });
 
       this.addCommand({
@@ -83,12 +76,8 @@ export default class QmdAsMdPlugin extends Plugin {
         name: 'Render Quarto to PDF',
         icon: 'file-output',
         callback: async () => {
-          const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-          if (activeView?.file && this.isQuartoFile(activeView.file)) {
-            await this.renderPdf(activeView.file);
-          } else {
-            new Notice('Current file is not a Quarto document');
-          }
+          const file = this.getActiveQuartoFile();
+          if (file) await this.renderPdf(file);
         },
       });
 
@@ -118,6 +107,24 @@ export default class QmdAsMdPlugin extends Plugin {
     return file.extension === 'qmd';
   }
 
+  getActiveQuartoFile(): TFile | null {
+    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (activeView?.file && this.isQuartoFile(activeView.file)) {
+      return activeView.file;
+    }
+    new Notice('Current file is not a Quarto document');
+    return null;
+  }
+
+  getVaultFullPath(file: TFile): string | null {
+    const adapter = this.app.vault.adapter;
+    if (adapter instanceof FileSystemAdapter) {
+      return adapter.getFullPath(file.path);
+    }
+    new Notice('Vault is not on a local filesystem; cannot run Quarto.');
+    return null;
+  }
+
   registerQmdExtension() {
     console.log('Registering .qmd as markdown...');
     this.registerExtensions(['qmd'], 'markdown');
@@ -144,7 +151,8 @@ export default class QmdAsMdPlugin extends Plugin {
         new Notice(`File ${file.path} not found`);
         return;
       }
-      const filePath = (this.app.vault.adapter as any).getFullPath(abstractFile.path);
+      const filePath = this.getVaultFullPath(abstractFile);
+      if (!filePath) return;
       const workingDir = path.dirname(filePath);
 
       console.log(`Resolved file path: ${filePath}`);
@@ -243,7 +251,8 @@ export default class QmdAsMdPlugin extends Plugin {
         return;
       }
 
-      const filePath = (this.app.vault.adapter as any).getFullPath(abstractFile.path);
+      const filePath = this.getVaultFullPath(abstractFile);
+      if (!filePath) return;
       const workingDir = path.dirname(filePath);
 
       const envVars: NodeJS.ProcessEnv = { ...process.env };
@@ -280,23 +289,32 @@ export default class QmdAsMdPlugin extends Plugin {
         const pdfVaultPath = file.path.replace(/\.qmd$/i, '.pdf');
         const pdfTFile = await this.waitForVaultFile(pdfVaultPath);
 
-        if (this.settings.openPdfInObsidian && pdfTFile) {
+        if (!pdfTFile) {
+          new Notice(
+            `Quarto rendered, but ${pdfVaultPath} did not appear in the vault within the timeout. Check Quarto's output-dir or vault sync.`
+          );
+          return;
+        }
+
+        if (!this.settings.openPdfInObsidian) {
+          new Notice(`PDF rendered: ${pdfVaultPath}`);
+          return;
+        }
+
+        try {
           const existing = this.app.workspace
             .getLeavesOfType('pdf')
             .find((l) => (l.view as any)?.file?.path === pdfTFile.path);
 
-          let leaf;
-          if (existing) {
-            leaf = existing;
-            await leaf.openFile(pdfTFile, { active: false });
-          } else {
-            leaf = this.app.workspace.getLeaf('split', 'vertical');
-            await leaf.openFile(pdfTFile, { active: false });
-          }
+          const leaf = existing ?? this.app.workspace.getLeaf('split', 'vertical');
+          await leaf.openFile(pdfTFile, { active: false });
           this.app.workspace.revealLeaf(leaf);
           new Notice(`Opened ${pdfVaultPath}`);
-        } else {
-          new Notice(`PDF rendered: ${pdfVaultPath}`);
+        } catch (err) {
+          console.error('Failed to open PDF in Obsidian:', err);
+          new Notice(
+            `PDF rendered at ${pdfVaultPath}, but Obsidian could not open it (no PDF viewer registered?).`
+          );
         }
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

- Adds **Render Quarto to PDF** command + ribbon icon (`file-output`) that runs `quarto render <file> --to pdf` on the active `.qmd`.
- New setting **Open Compiled PDF in Obsidian** (off by default). When on, the rendered PDF opens in a vertical split via Obsidian's built-in PDF viewer. Source tab keeps focus.
- Re-running render reuses the existing PDF leaf instead of stacking new tabs.
- Command exposes an `icon`, so plugins like **Commander** can surface it in the toolbar.
- Version bumped to `0.1.0-rc.1` as a **BRAT-only** beta:
  - `manifest.json` stays at `0.0.3` (community store).
  - new `manifest-beta.json` carries `0.1.0-rc.1` for BRAT.
  - `package.json` matches the beta version.
- README documents the new feature, version history entry, and BRAT install flow.

## Why

Existing `Toggle Quarto Preview` runs `quarto preview` (HTML server) and opens it in a webviewer. Some workflows need a one-shot PDF compile and an inline PDF viewer alongside the source — handled now by the new command + setting. Splitting right (instead of replacing the source tab) and reusing the PDF leaf on recompile gives a stable side-by-side editing loop.

Shipping behind BRAT first so testers can shake it out before promotion to the community store (the `-rc.x` suffix is rejected by the store schema, by design).

## Reviewer notes

- `.qmd` source must live inside the vault — Obsidian's PDF viewer only opens vault files. Out-of-vault sources will render but won't auto-open.
- Plugin looks for `<basename>.pdf` next to the source. Custom `output-dir` in `_quarto.yml` is **not** handled yet — flagged in README as a known limitation.
- Existing preview, hotkeys, and other settings are untouched.
- Build verified with `npm run build` (rollup, no errors).

## Test plan

- [ ] Install via BRAT from this branch, confirm `manifest-beta.json` is picked up and version reads `0.1.0-rc.1`.
- [ ] Open a `.qmd` in vault, run **Render Quarto to PDF** with toggle **off** → notice shows PDF path, no tab opens.
- [ ] Run again with toggle **on** → PDF opens in right split, source keeps focus.
- [ ] Edit `.qmd`, re-run render → existing PDF tab reloads in place, no new tab.
- [ ] Confirm Commander plugin shows `file-output` icon for the command.
- [ ] Confirm existing `Toggle Quarto Preview` still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Quarto-to-PDF rendering workflow for .qmd files in Obsidian and ship it as a BRAT-only beta release.

New Features:
- Introduce a Render Quarto to PDF command and ribbon icon that runs Quarto on the active .qmd file.
- Add an option to open the compiled PDF inside Obsidian using the built-in PDF viewer in a side-by-side split with the source.
- Ensure repeated PDF renders reuse an existing PDF tab instead of opening new tabs.

Enhancements:
- Extend plugin settings with a toggle to control whether rendered PDFs are opened inside Obsidian.

Build:
- Bump the package version to 0.1.0-rc.1 and add a beta manifest file for BRAT-based distribution.

Documentation:
- Document the new PDF rendering workflow, its limitations, and how to access the beta via BRAT, including a version history entry.