### PR TITLE
fix: reuse PDF leaf across re-renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,45 @@ To contribute or customize the plugin:
 Alternatively, clone the repository directly into your plugins folder. After installing dependencies, run `npm run dev` to enable watch mode for live compilation.  
 Reload Obsidian (`Ctrl + R`) to view updates.
 
+### Make targets
+
+The `makefile` wraps common tasks. Run `make help` for the list:
+
+| Target           | What it does                                                                 |
+|------------------|------------------------------------------------------------------------------|
+| `make build`     | `npm install`, build `main.js`, zip, clean.                                  |
+| `make zip`       | Bundle `main.js` + `manifest.json` into `qmd-as-md.zip`.                     |
+| `make clean`     | Wipe `node_modules`, build artefacts, lockfile.                              |
+| `make audit`     | `npm audit` — security advisories for current dependency tree.               |
+| `make outdated`  | `npm outdated` — newer upstream versions available.                          |
+| `make check-deps`| Run both `audit` and `outdated`.                                             |
+
+### Cutting a release
+
+Two release channels share the same `main` branch:
+
+- **Stable** — `manifest.json` is the source of truth (e.g. `0.0.3`). Goes to the community plugin store.
+- **Beta** — `manifest-beta.json` is the source of truth (e.g. `0.1.0-rc.1`). Distributed only via [BRAT](https://github.com/TfTHacker/obsidian42-brat). Pre-release semver suffixes (`-rc.x`, `-beta.x`) are accepted by BRAT but rejected by the community store, so betas live exclusively here.
+
+To publish a release:
+
+```bash
+# Beta — bump manifest-beta.json first, then:
+make release-beta                          # interactive prompt for notes
+make release-beta NOTES="Fixed leaf bug"   # non-interactive
+
+# Stable — bump manifest.json first, then:
+make release-stable
+```
+
+Both targets:
+1. Read the version from the appropriate manifest.
+2. Refuse to overwrite an existing tag.
+3. Build `main.js` fresh.
+4. Create a GitHub release tagged with the version (no `v` prefix — Obsidian convention) and attach `main.js` plus the correctly-versioned `manifest.json`. The beta target uploads `manifest-beta.json` renamed to `manifest.json` so BRAT finds the expected asset name.
+5. Mark beta releases as `--prerelease`.
+
+Requirements: `gh` authenticated against the repo, working tree clean, `node` available.
+
+After a beta release, BRAT users can hit **Check for updates to all beta plugins** to pull it.
+

--- a/makefile
+++ b/makefile
@@ -2,7 +2,67 @@ zip:
 	zip qmd-as-md.zip main.js manifest.json
 
 clean:
-	rm -rf node_modules dist build .cache *.log *.tmp package-lock.json 
+	rm -rf node_modules dist build .cache *.log *.tmp package-lock.json
 
 build:
 	npm install && npm run build && make zip && make clean
+
+# --- Releases ---------------------------------------------------------------
+# Publish a GitHub release whose assets BRAT (or the community store) reads.
+#
+#   make release-beta        # reads version from manifest-beta.json
+#   make release-stable      # reads version from manifest.json
+#
+# Both targets prompt for release notes (Enter accepts the default).
+# Override the prompt non-interactively:
+#   make release-beta NOTES="Fixed re-render leaf bug"
+#
+# Requires: gh authenticated, node, working tree clean.
+
+release-beta:
+	@VERSION=$$(node -p "require('./manifest-beta.json').version"); \
+	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest-beta.json"; exit 1; fi; \
+	if gh release view $$VERSION >/dev/null 2>&1; then \
+		echo "Release $$VERSION already exists. Bump manifest-beta.json first."; exit 1; \
+	fi; \
+	if [ -z "$(NOTES)" ]; then \
+		read -p "Release notes [Beta release $$VERSION]: " INPUT_NOTES; \
+		FINAL_NOTES="$${INPUT_NOTES:-Beta release $$VERSION}"; \
+	else \
+		FINAL_NOTES="$(NOTES)"; \
+	fi; \
+	echo "→ Building main.js..."; \
+	npm install --silent && npm run build; \
+	echo "→ Staging manifest-beta.json as the release's manifest.json..."; \
+	cp manifest-beta.json /tmp/qmd-release-manifest.json; \
+	echo "→ Creating GitHub pre-release $$VERSION..."; \
+	gh release create $$VERSION \
+		--title "$$VERSION (beta)" \
+		--prerelease \
+		--notes "$$FINAL_NOTES" \
+		main.js "/tmp/qmd-release-manifest.json#manifest.json"; \
+	rm /tmp/qmd-release-manifest.json; \
+	echo "✓ Released $$VERSION (beta). BRAT users: 'Check for updates'."
+
+release-stable:
+	@VERSION=$$(node -p "require('./manifest.json').version"); \
+	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest.json"; exit 1; fi; \
+	if gh release view $$VERSION >/dev/null 2>&1; then \
+		echo "Release $$VERSION already exists. Bump manifest.json first."; exit 1; \
+	fi; \
+	if [ -z "$(NOTES)" ]; then \
+		read -p "Release notes [Stable release $$VERSION]: " INPUT_NOTES; \
+		FINAL_NOTES="$${INPUT_NOTES:-Stable release $$VERSION}"; \
+	else \
+		FINAL_NOTES="$(NOTES)"; \
+	fi; \
+	echo "→ Building main.js..."; \
+	npm install --silent && npm run build; \
+	echo "→ Creating GitHub release $$VERSION..."; \
+	gh release create $$VERSION \
+		--title "$$VERSION" \
+		--notes "$$FINAL_NOTES" \
+		main.js manifest.json; \
+	echo "✓ Released $$VERSION (stable)."
+
+.PHONY: zip clean build release-beta release-stable

--- a/makefile
+++ b/makefile
@@ -1,3 +1,14 @@
+help:
+	@echo "Targets:"
+	@echo "  build           Install deps, build main.js, zip, then clean."
+	@echo "  zip             Bundle main.js + manifest.json into qmd-as-md.zip."
+	@echo "  clean           Remove node_modules, build artefacts, lockfile."
+	@echo "  audit           npm audit — security advisories for current deps."
+	@echo "  outdated        npm outdated — newer versions available upstream."
+	@echo "  check-deps      Run both audit and outdated."
+	@echo "  release-beta    Publish GitHub pre-release from manifest-beta.json."
+	@echo "  release-stable  Publish GitHub release from manifest.json."
+
 zip:
 	zip qmd-as-md.zip main.js manifest.json
 
@@ -6,6 +17,19 @@ clean:
 
 build:
 	npm install && npm run build && make zip && make clean
+
+# --- Dependency health ------------------------------------------------------
+
+audit:
+	@npm install --silent
+	npm audit
+
+outdated:
+	@npm install --silent
+	@npm outdated || true   # exit 1 when something is outdated; not a failure
+
+check-deps: audit outdated
+	@echo "✓ Dependency check complete."
 
 # --- Releases ---------------------------------------------------------------
 # Publish a GitHub release whose assets BRAT (or the community store) reads.
@@ -65,4 +89,4 @@ release-stable:
 		main.js manifest.json; \
 	echo "✓ Released $$VERSION (stable)."
 
-.PHONY: zip clean build release-beta release-stable
+.PHONY: help zip clean build audit outdated check-deps release-beta release-stable

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,6 +125,10 @@ export default class QmdAsMdPlugin extends Plugin {
     return null;
   }
 
+  pdfPathFor(qmdFile: TFile): string {
+    return qmdFile.path.replace(/\.qmd$/i, '.pdf');
+  }
+
   registerQmdExtension() {
     console.log('Registering .qmd as markdown...');
     this.registerExtensions(['qmd'], 'markdown');
@@ -262,7 +266,7 @@ export default class QmdAsMdPlugin extends Plugin {
 
       new Notice('Rendering Quarto to PDF...');
 
-      const pdfVaultPath = file.path.replace(/\.qmd$/i, '.pdf');
+      const pdfVaultPath = this.pdfPathFor(file);
       const existingLeaf = this.app.workspace
         .getLeavesOfType('pdf')
         .find((l) => (l.view as any)?.file?.path === pdfVaultPath);
@@ -306,10 +310,8 @@ export default class QmdAsMdPlugin extends Plugin {
         }
 
         try {
-          const stillAttached =
-            existingLeaf && (existingLeaf as any).parent != null;
-          const leaf = stillAttached
-            ? existingLeaf!
+          const leaf = existingLeaf?.parent != null
+            ? existingLeaf
             : this.app.workspace.getLeaf('split', 'vertical');
           await leaf.openFile(pdfTFile, { active: false });
           this.app.workspace.revealLeaf(leaf);

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,11 @@ export default class QmdAsMdPlugin extends Plugin {
 
       new Notice('Rendering Quarto to PDF...');
 
+      const pdfVaultPath = file.path.replace(/\.qmd$/i, '.pdf');
+      const existingLeaf = this.app.workspace
+        .getLeavesOfType('pdf')
+        .find((l) => (l.view as any)?.file?.path === pdfVaultPath);
+
       const quartoProcess = spawn(
         this.settings.quartoPath,
         ['render', filePath, '--to', 'pdf'],
@@ -286,7 +291,6 @@ export default class QmdAsMdPlugin extends Plugin {
           return;
         }
 
-        const pdfVaultPath = file.path.replace(/\.qmd$/i, '.pdf');
         const pdfTFile = await this.waitForVaultFile(pdfVaultPath);
 
         if (!pdfTFile) {
@@ -302,11 +306,11 @@ export default class QmdAsMdPlugin extends Plugin {
         }
 
         try {
-          const existing = this.app.workspace
-            .getLeavesOfType('pdf')
-            .find((l) => (l.view as any)?.file?.path === pdfTFile.path);
-
-          const leaf = existing ?? this.app.workspace.getLeaf('split', 'vertical');
+          const stillAttached =
+            existingLeaf && (existingLeaf as any).parent != null;
+          const leaf = stillAttached
+            ? existingLeaf!
+            : this.app.workspace.getLeaf('split', 'vertical');
           await leaf.openFile(pdfTFile, { active: false });
           this.app.workspace.revealLeaf(leaf);
           new Notice(`Opened ${pdfVaultPath}`);


### PR DESCRIPTION
## Summary

Follow-up to #5. Fixes leaf-stacking bug discovered during testing.

## Bug

Quarto render = delete-old + write-new. By the time the close handler ran:
- old file gone from vault
- existing PDF leaf's `view.file` cleared
- `getLeavesOfType('pdf')` no longer returned that leaf
- lookup missed → fell into `getLeaf('split', 'vertical')` → new tab every recompile, empty leaf left behind

## Fix

Capture leaf reference *before* spawning Quarto (file binding still intact). After render, reopen on same leaf object — workspace still holds it, just with cleared view. Fallback to fresh split if user closed it mid-render.

## Test plan

- [ ] Render once with toggle on → PDF opens in right split.
- [ ] Edit `.qmd`, render again → same leaf reloads, no new tab.
- [ ] Close PDF leaf manually, render again → fresh split opens (fallback works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Preserve and reuse the existing PDF workspace leaf across Quarto re-renders, falling back to a new split only if the original leaf is no longer attached.