### PR TITLE
fix(make): surface release-target failures with set -e

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,7 +44,10 @@ check-deps: audit outdated
 # Requires: gh authenticated, node, working tree clean.
 
 release-beta:
-	@VERSION=$$(node -p "require('./manifest-beta.json').version"); \
+	@set -e; \
+	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
+	command -v node >/dev/null || { echo "node not found"; exit 1; }; \
+	VERSION=$$(node -p "require('./manifest-beta.json').version"); \
 	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest-beta.json"; exit 1; fi; \
 	if gh release view $$VERSION >/dev/null 2>&1; then \
 		echo "Release $$VERSION already exists. Bump manifest-beta.json first."; exit 1; \
@@ -56,7 +59,9 @@ release-beta:
 		FINAL_NOTES="$(NOTES)"; \
 	fi; \
 	echo "→ Building main.js..."; \
-	npm install --silent && npm run build; \
+	npm install; \
+	npm run build; \
+	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }; \
 	echo "→ Staging manifest-beta.json as the release's manifest.json..."; \
 	cp manifest-beta.json /tmp/qmd-release-manifest.json; \
 	echo "→ Creating GitHub pre-release $$VERSION..."; \
@@ -69,7 +74,10 @@ release-beta:
 	echo "✓ Released $$VERSION (beta). BRAT users: 'Check for updates'."
 
 release-stable:
-	@VERSION=$$(node -p "require('./manifest.json').version"); \
+	@set -e; \
+	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
+	command -v node >/dev/null || { echo "node not found"; exit 1; }; \
+	VERSION=$$(node -p "require('./manifest.json').version"); \
 	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest.json"; exit 1; fi; \
 	if gh release view $$VERSION >/dev/null 2>&1; then \
 		echo "Release $$VERSION already exists. Bump manifest.json first."; exit 1; \
@@ -81,7 +89,9 @@ release-stable:
 		FINAL_NOTES="$(NOTES)"; \
 	fi; \
 	echo "→ Building main.js..."; \
-	npm install --silent && npm run build; \
+	npm install; \
+	npm run build; \
+	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }; \
 	echo "→ Creating GitHub release $$VERSION..."; \
 	gh release create $$VERSION \
 		--title "$$VERSION" \

--- a/makefile
+++ b/makefile
@@ -62,15 +62,16 @@ release-beta:
 	npm install; \
 	npm run build; \
 	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }; \
-	echo "→ Staging manifest-beta.json as the release's manifest.json..."; \
-	cp manifest-beta.json /tmp/qmd-release-manifest.json; \
+	echo "→ Staging manifest-beta.json as a file literally named manifest.json..."; \
+	STAGE=$$(mktemp -d); \
+	cp manifest-beta.json $$STAGE/manifest.json; \
 	echo "→ Creating GitHub pre-release $$VERSION..."; \
 	gh release create $$VERSION \
 		--title "$$VERSION (beta)" \
 		--prerelease \
 		--notes "$$FINAL_NOTES" \
-		main.js "/tmp/qmd-release-manifest.json#manifest.json"; \
-	rm /tmp/qmd-release-manifest.json; \
+		main.js $$STAGE/manifest.json; \
+	rm -rf $$STAGE; \
 	echo "✓ Released $$VERSION (beta). BRAT users: 'Check for updates'."
 
 release-stable:

--- a/makefile
+++ b/makefile
@@ -1,3 +1,7 @@
+.ONESHELL:
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+
 help:
 	@echo "Targets:"
 	@echo "  build           Install deps, build main.js, zip, then clean."
@@ -16,17 +20,20 @@ clean:
 	rm -rf node_modules dist build .cache *.log *.tmp package-lock.json
 
 build:
-	npm install && npm run build && make zip && make clean
+	npm install
+	npm run build
+	$(MAKE) zip
+	$(MAKE) clean
 
 # --- Dependency health ------------------------------------------------------
 
 audit:
-	@npm install --silent
+	npm install
 	npm audit
 
 outdated:
-	@npm install --silent
-	@npm outdated || true   # exit 1 when something is outdated; not a failure
+	npm install
+	npm outdated || true   # exit 1 when something is outdated; not a failure
 
 check-deps: audit outdated
 	@echo "✓ Dependency check complete."
@@ -43,61 +50,71 @@ check-deps: audit outdated
 #
 # Requires: gh authenticated, node, working tree clean.
 
+# Shared release helpers. Used by both release-beta and release-stable so
+# tool checks, install, build, and main.js verification live in one place.
+
+define preflight
+	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }
+	command -v node >/dev/null || { echo "node not found"; exit 1; }
+endef
+
+# `npm ci` gives reproducible installs from package-lock.json. The lockfile
+# is gitignored in this repo, so fall back to `npm install` when it is
+# absent (e.g. fresh clone, or right after `make clean`).
+define build_main_js
+	echo "→ Building main.js..."
+	if [ -f package-lock.json ]; then npm ci; else npm install; fi
+	npm run build
+	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }
+endef
+
 release-beta:
-	@set -e; \
-	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
-	command -v node >/dev/null || { echo "node not found"; exit 1; }; \
-	VERSION=$$(node -p "require('./manifest-beta.json').version"); \
-	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest-beta.json"; exit 1; fi; \
-	if gh release view $$VERSION >/dev/null 2>&1; then \
-		echo "Release $$VERSION already exists. Bump manifest-beta.json first."; exit 1; \
-	fi; \
-	if [ -z "$(NOTES)" ]; then \
-		read -p "Release notes [Beta release $$VERSION]: " INPUT_NOTES; \
-		FINAL_NOTES="$${INPUT_NOTES:-Beta release $$VERSION}"; \
-	else \
-		FINAL_NOTES="$(NOTES)"; \
-	fi; \
-	echo "→ Building main.js..."; \
-	npm install; \
-	npm run build; \
-	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }; \
-	echo "→ Staging manifest-beta.json as a file literally named manifest.json..."; \
-	STAGE=$$(mktemp -d); \
-	cp manifest-beta.json $$STAGE/manifest.json; \
-	echo "→ Creating GitHub pre-release $$VERSION..."; \
+	$(preflight)
+	VERSION=$$(node -p "require('./manifest-beta.json').version")
+	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest-beta.json"; exit 1; fi
+	if gh release view $$VERSION >/dev/null 2>&1; then
+		echo "Release $$VERSION already exists. Bump manifest-beta.json first."
+		exit 1
+	fi
+	if [ -z "$(NOTES)" ]; then
+		read -p "Release notes [Beta release $$VERSION]: " INPUT_NOTES || true
+		FINAL_NOTES="$${INPUT_NOTES:-Beta release $$VERSION}"
+	else
+		FINAL_NOTES="$(NOTES)"
+	fi
+	$(build_main_js)
+	echo "→ Staging manifest-beta.json as a file literally named manifest.json..."
+	STAGE=$$(mktemp -d)
+	cp manifest-beta.json $$STAGE/manifest.json
+	echo "→ Creating GitHub pre-release $$VERSION..."
 	gh release create $$VERSION \
 		--title "$$VERSION (beta)" \
 		--prerelease \
 		--notes "$$FINAL_NOTES" \
-		main.js $$STAGE/manifest.json; \
-	rm -rf $$STAGE; \
+		main.js $$STAGE/manifest.json
+	rm -rf $$STAGE
 	echo "✓ Released $$VERSION (beta). BRAT users: 'Check for updates'."
 
 release-stable:
-	@set -e; \
-	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
-	command -v node >/dev/null || { echo "node not found"; exit 1; }; \
-	VERSION=$$(node -p "require('./manifest.json').version"); \
-	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest.json"; exit 1; fi; \
-	if gh release view $$VERSION >/dev/null 2>&1; then \
-		echo "Release $$VERSION already exists. Bump manifest.json first."; exit 1; \
-	fi; \
-	if [ -z "$(NOTES)" ]; then \
-		read -p "Release notes [Stable release $$VERSION]: " INPUT_NOTES; \
-		FINAL_NOTES="$${INPUT_NOTES:-Stable release $$VERSION}"; \
-	else \
-		FINAL_NOTES="$(NOTES)"; \
-	fi; \
-	echo "→ Building main.js..."; \
-	npm install; \
-	npm run build; \
-	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }; \
-	echo "→ Creating GitHub release $$VERSION..."; \
+	$(preflight)
+	VERSION=$$(node -p "require('./manifest.json').version")
+	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest.json"; exit 1; fi
+	if gh release view $$VERSION >/dev/null 2>&1; then
+		echo "Release $$VERSION already exists. Bump manifest.json first."
+		exit 1
+	fi
+	if [ -z "$(NOTES)" ]; then
+		read -p "Release notes [Stable release $$VERSION]: " INPUT_NOTES || true
+		FINAL_NOTES="$${INPUT_NOTES:-Stable release $$VERSION}"
+	else
+		FINAL_NOTES="$(NOTES)"
+	fi
+	$(build_main_js)
+	echo "→ Creating GitHub release $$VERSION..."
 	gh release create $$VERSION \
 		--title "$$VERSION" \
 		--notes "$$FINAL_NOTES" \
-		main.js manifest.json; \
+		main.js manifest.json
 	echo "✓ Released $$VERSION (stable)."
 
 .PHONY: help zip clean build audit outdated check-deps release-beta release-stable


### PR DESCRIPTION
## Why

Followup: `make release-beta` ran but no GitHub release appeared (`0.1.0-rc.2` missing). The recipe used `\`-joined commands without `set -e`, so when `npm install`/`npm run build` failed silently the chain kept going and `gh release create` errored on a missing or stale `main.js` — without any clear signal to the operator.

## Fix

- `set -e` at the start of each release recipe — first failure aborts.
- Drop `--silent` from `npm install` so install errors show up.
- Pre-flight check that `gh` and `node` exist.
- Post-build check that `main.js` was actually produced.

Applied identically to `release-stable`.

## Re-running

After this lands, run `make release-beta` again. Any actual error (auth, network, missing tool) will now stop the recipe and print the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the beta and stable release make targets so that failures in build tooling or missing artifacts cause the release process to abort with clear errors.

Bug Fixes:
- Ensure release-beta and release-stable targets abort on the first failing command instead of continuing silently.
- Expose npm install and build errors by removing silent flags and separating install and build steps.
- Prevent releases from proceeding when required tools (gh CLI, node) are missing or the main.js build artifact is not produced.