### PR TITLE
docs+fix: Make 3.81 compat, version-read diagnostics, troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The `makefile` wraps common tasks. Run `make help` for the list:
 
 | Target              | What it does                                                                                |
 |---------------------|---------------------------------------------------------------------------------------------|
-| `make build`        | `npm install`, build `main.js`, then zip.                                                   |
+| `make build`        | Install deps (`npm ci` when `package-lock.json` exists, otherwise `npm install`), build `main.js`, then zip. |
 | `make zip`          | Bundle `main.js` + `manifest.json` into `qmd-as-md.zip`.                                    |
 | `make clean`        | Wipe `node_modules` and build artefacts.                                                    |
 | `make release-beta` | Publish a GitHub pre-release using the version in `manifest-beta.json`.                     |

--- a/README.md
+++ b/README.md
@@ -152,14 +152,13 @@ Reload Obsidian (`Ctrl + R`) to view updates.
 
 The `makefile` wraps common tasks. Run `make help` for the list:
 
-| Target           | What it does                                                                 |
-|------------------|------------------------------------------------------------------------------|
-| `make build`     | `npm install`, build `main.js`, zip, clean.                                  |
-| `make zip`       | Bundle `main.js` + `manifest.json` into `qmd-as-md.zip`.                     |
-| `make clean`     | Wipe `node_modules`, build artefacts, lockfile.                              |
-| `make audit`     | `npm audit` — security advisories for current dependency tree.               |
-| `make outdated`  | `npm outdated` — newer upstream versions available.                          |
-| `make check-deps`| Run both `audit` and `outdated`.                                             |
+| Target              | What it does                                                                                |
+|---------------------|---------------------------------------------------------------------------------------------|
+| `make build`        | `npm install`, build `main.js`, then zip.                                                   |
+| `make zip`          | Bundle `main.js` + `manifest.json` into `qmd-as-md.zip`.                                    |
+| `make clean`        | Wipe `node_modules` and build artefacts.                                                    |
+| `make release-beta` | Publish a GitHub pre-release using the version in `manifest-beta.json`.                     |
+| `make release-stable` | Publish a GitHub release using the version in `manifest.json`.                            |
 
 ### Cutting a release
 
@@ -180,13 +179,48 @@ make release-stable
 ```
 
 Both targets:
-1. Read the version from the appropriate manifest.
-2. Refuse to overwrite an existing tag.
-3. Build `main.js` fresh.
-4. Create a GitHub release tagged with the version (no `v` prefix — Obsidian convention) and attach `main.js` plus the correctly-versioned `manifest.json`. The beta target uploads `manifest-beta.json` renamed to `manifest.json` so BRAT finds the expected asset name.
+1. Check that `gh`, `node`, `npm`, and `zip` are on `PATH`.
+2. Read the version from the appropriate manifest, and refuse to overwrite an existing tag.
+3. Build `main.js` fresh (`npm ci` if `package-lock.json` exists, otherwise `npm install`).
+4. Create a GitHub release tagged with the version (no `v` prefix — Obsidian convention) and attach `main.js` plus a correctly-versioned `manifest.json`. The beta target stages `manifest-beta.json` into a tempdir under the literal name `manifest.json` so BRAT finds the asset it expects.
 5. Mark beta releases as `--prerelease`.
 
-Requirements: `gh` authenticated against the repo, working tree clean, `node` available.
+Requirements: `gh` authenticated against the repo, working tree clean.
 
 After a beta release, BRAT users can hit **Check for updates to all beta plugins** to pull it.
+
+### Troubleshooting the release flow
+
+#### `Could not read version from manifest-beta.json` / empty version
+
+The recipe runs `node -p "require('./manifest-beta.json').version"` and treats an empty result as a hard error. Common causes:
+
+- **Wrong working directory.** The recipe expects to be run from the repo root. `cd` to it (`pwd` should show the directory containing `manifest-beta.json`) before running `make`.
+- **Manifest missing or malformed.** The recipe now prints the real Node.js error before bailing — read the message rather than the generic line.
+- **`gh` not authenticated for this repo.** Run `gh auth status` and `gh repo set-default danieltomasz/qmd-as-md-obsidian` if needed.
+
+#### Variables silently lost between recipe lines (macOS default Make)
+
+macOS ships **GNU Make 3.81** (released 2006), which predates `.ONESHELL` (added in 3.82, 2010). On 3.81 the directive is silently ignored, so each recipe line runs in its own shell and any variable set on one line is gone by the next. The recipes in this repo are written as single `\`-joined shell invocations specifically to remain compatible with 3.81 — do **not** add `.ONESHELL` back without verifying the local `make --version`.
+
+If you want a modern Make on macOS:
+
+```bash
+brew install make
+gmake release-beta NOTES="…"      # invoked as `gmake`, not `make`
+```
+
+#### BRAT says "this is not an Obsidian plugin"
+
+BRAT walks the latest GitHub release looking for an asset named literally `manifest.json`. The previous version of this Makefile relied on `gh release create`'s `path#displayname` rename syntax, which silently no-op'd in some `gh` CLI versions and uploaded the asset under its real basename (e.g. `qmd-release-manifest.json`) — invisible to BRAT. The current recipe sidesteps the rename mechanism by staging the file under the correct name in a tempdir before upload. If BRAT still rejects a release, inspect the assets:
+
+```bash
+gh release view <tag> | grep -i asset
+```
+
+The list must contain both `main.js` and `manifest.json` (exact spelling).
+
+#### Release was created but `gh release create` failed silently
+
+Older versions of the recipe used long `\`-joined chains without `set -e`. A failed `npm install`/`npm run build` or missing tool would let the chain continue past the failure, eventually erroring on `gh release create` with no clear cause. The current recipe sets `set -e` at the start of each release target, validates each tool with `command -v`, and verifies `main.js` was produced before invoking `gh`. If something still goes wrong, the first error surfaced by the recipe is the real one — read up, not down.
 

--- a/makefile
+++ b/makefile
@@ -11,8 +11,7 @@ SHELL := /bin/bash
 define preflight
 command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
 command -v node >/dev/null || { echo "node not found"; exit 1; }; \
-command -v npm >/dev/null || { echo "npm not found"; exit 1; }; \
-command -v zip >/dev/null || { echo "zip not found"; exit 1; }
+command -v npm >/dev/null || { echo "npm not found"; exit 1; }
 endef
 
 define build_main_js
@@ -93,7 +92,7 @@ release-beta:
 	fi; \
 	$(build_main_js); \
 	echo "→ Staging manifest-beta.json as manifest.json..."; \
-	STAGE=$$(mktemp -d); \
+	STAGE=$$(mktemp -d -t qmd-as-md.XXXXXX); \
 	cp manifest-beta.json "$$STAGE/manifest.json"; \
 	echo "→ Creating GitHub pre-release $$VERSION..."; \
 	gh release create "$$VERSION" \

--- a/makefile
+++ b/makefile
@@ -22,20 +22,37 @@ npm run build; \
 [ -f main.js ] || { echo "main.js not produced by build"; exit 1; }
 endef
 
-# Reads .version from the manifest in $$MANIFEST and exports VERSION.
-# Surfaces the real node/JSON error: bash's `VAR=$(failing-cmd)` does
-# NOT trip `set -e`, so without explicit capture a missing file or
-# malformed JSON would silently leave VERSION empty and the caller
-# would only see a generic message.
+# Reads .version from the manifest in $$MANIFEST and sets VERSION.
+# Captures node's exit code explicitly so a missing file, malformed
+# JSON, or a missing `.version` field surface their real cause
+# instead of a generic message. The `&& RC=0 || RC=$$?` form is
+# required because under `set -e` a bare failing command substitution
+# would abort the recipe before we could read $$?.
 define read_version
 [ -f "$$MANIFEST" ] || { echo "$$MANIFEST not found in $$(pwd). Run make from the repo root."; exit 1; }; \
-VERSION=$$(node -p "require('./$$MANIFEST').version" 2>&1) || { echo "Failed to read version from $$MANIFEST:"; echo "$$VERSION"; exit 1; }; \
+NODE_OUT=$$(node -p "require('./$$MANIFEST').version" 2>&1) && RC=0 || RC=$$?; \
+if [ $$RC -ne 0 ]; then \
+	echo "Failed to read version from $$MANIFEST:"; \
+	echo "$$NODE_OUT"; \
+	exit 1; \
+fi; \
+VERSION="$$NODE_OUT"; \
 if [ -z "$$VERSION" ] || [ "$$VERSION" = "undefined" ]; then \
 	echo "$$MANIFEST has no .version field"; exit 1; \
 fi
 endef
 
 # --- Standard targets ------------------------------------------------------
+
+help:
+	@echo "Targets:"
+	@echo "  build           Install deps, build main.js, then zip."
+	@echo "  zip             Bundle main.js + manifest.json into qmd-as-md.zip."
+	@echo "  clean           Remove node_modules and build artefacts."
+	@echo "  release-beta    Publish GitHub pre-release from manifest-beta.json."
+	@echo "  release-stable  Publish GitHub release from manifest.json."
+	@echo ""
+	@echo "Optional: NOTES=\"...\" passes non-interactive release notes."
 
 zip:
 	zip qmd-as-md.zip main.js manifest.json
@@ -44,7 +61,9 @@ clean:
 	rm -rf node_modules dist build .cache *.log *.tmp
 
 build:
-	npm install && npm run build && $(MAKE) zip
+	@set -e; \
+	$(build_main_js); \
+	$(MAKE) zip
 
 # --- Releases --------------------------------------------------------------
 # Publish a GitHub release whose assets BRAT (or the community store) reads.
@@ -107,4 +126,4 @@ release-stable:
 		main.js manifest.json; \
 	echo "✓ Released $$VERSION stable."
 
-.PHONY: zip clean build release-beta release-stable
+.PHONY: help zip clean build release-beta release-stable

--- a/makefile
+++ b/makefile
@@ -1,44 +1,52 @@
-.ONESHELL:
 SHELL := /bin/bash
-.SHELLFLAGS := -eu -o pipefail -c
 
-help:
-	@echo "Targets:"
-	@echo "  build           Install deps, build main.js, zip, then clean."
-	@echo "  zip             Bundle main.js + manifest.json into qmd-as-md.zip."
-	@echo "  clean           Remove node_modules, build artefacts, lockfile."
-	@echo "  audit           npm audit — security advisories for current deps."
-	@echo "  outdated        npm outdated — newer versions available upstream."
-	@echo "  check-deps      Run both audit and outdated."
-	@echo "  release-beta    Publish GitHub pre-release from manifest-beta.json."
-	@echo "  release-stable  Publish GitHub release from manifest.json."
+# macOS ships GNU Make 3.81, which predates .ONESHELL (3.82+). Recipes
+# must be `\`-joined into a single shell invocation so set -e and
+# variables propagate between lines.
+
+# --- Shared macros ---------------------------------------------------------
+# Each macro is a single `\`-joined shell fragment that ends without a
+# trailing semicolon — the caller adds `;` and continues the chain.
+
+define preflight
+command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }; \
+command -v node >/dev/null || { echo "node not found"; exit 1; }; \
+command -v npm >/dev/null || { echo "npm not found"; exit 1; }; \
+command -v zip >/dev/null || { echo "zip not found"; exit 1; }
+endef
+
+define build_main_js
+echo "→ Building main.js..."; \
+if [ -f package-lock.json ]; then npm ci; else npm install; fi; \
+npm run build; \
+[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }
+endef
+
+# Reads .version from the manifest in $$MANIFEST and exports VERSION.
+# Surfaces the real node/JSON error: bash's `VAR=$(failing-cmd)` does
+# NOT trip `set -e`, so without explicit capture a missing file or
+# malformed JSON would silently leave VERSION empty and the caller
+# would only see a generic message.
+define read_version
+[ -f "$$MANIFEST" ] || { echo "$$MANIFEST not found in $$(pwd). Run make from the repo root."; exit 1; }; \
+VERSION=$$(node -p "require('./$$MANIFEST').version" 2>&1) || { echo "Failed to read version from $$MANIFEST:"; echo "$$VERSION"; exit 1; }; \
+if [ -z "$$VERSION" ] || [ "$$VERSION" = "undefined" ]; then \
+	echo "$$MANIFEST has no .version field"; exit 1; \
+fi
+endef
+
+# --- Standard targets ------------------------------------------------------
 
 zip:
 	zip qmd-as-md.zip main.js manifest.json
 
 clean:
-	rm -rf node_modules dist build .cache *.log *.tmp package-lock.json
+	rm -rf node_modules dist build .cache *.log *.tmp
 
 build:
-	npm install
-	npm run build
-	$(MAKE) zip
-	$(MAKE) clean
+	npm install && npm run build && $(MAKE) zip
 
-# --- Dependency health ------------------------------------------------------
-
-audit:
-	npm install
-	npm audit
-
-outdated:
-	npm install
-	npm outdated || true   # exit 1 when something is outdated; not a failure
-
-check-deps: audit outdated
-	@echo "✓ Dependency check complete."
-
-# --- Releases ---------------------------------------------------------------
+# --- Releases --------------------------------------------------------------
 # Publish a GitHub release whose assets BRAT (or the community store) reads.
 #
 #   make release-beta        # reads version from manifest-beta.json
@@ -50,71 +58,53 @@ check-deps: audit outdated
 #
 # Requires: gh authenticated, node, working tree clean.
 
-# Shared release helpers. Used by both release-beta and release-stable so
-# tool checks, install, build, and main.js verification live in one place.
-
-define preflight
-	command -v gh >/dev/null || { echo "gh CLI not found. Install from https://cli.github.com"; exit 1; }
-	command -v node >/dev/null || { echo "node not found"; exit 1; }
-endef
-
-# `npm ci` gives reproducible installs from package-lock.json. The lockfile
-# is gitignored in this repo, so fall back to `npm install` when it is
-# absent (e.g. fresh clone, or right after `make clean`).
-define build_main_js
-	echo "→ Building main.js..."
-	if [ -f package-lock.json ]; then npm ci; else npm install; fi
-	npm run build
-	[ -f main.js ] || { echo "main.js not produced by build"; exit 1; }
-endef
-
 release-beta:
-	$(preflight)
-	VERSION=$$(node -p "require('./manifest-beta.json').version")
-	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest-beta.json"; exit 1; fi
-	if gh release view $$VERSION >/dev/null 2>&1; then
-		echo "Release $$VERSION already exists. Bump manifest-beta.json first."
-		exit 1
-	fi
-	if [ -z "$(NOTES)" ]; then
-		read -p "Release notes [Beta release $$VERSION]: " INPUT_NOTES || true
-		FINAL_NOTES="$${INPUT_NOTES:-Beta release $$VERSION}"
-	else
-		FINAL_NOTES="$(NOTES)"
-	fi
-	$(build_main_js)
-	echo "→ Staging manifest-beta.json as a file literally named manifest.json..."
-	STAGE=$$(mktemp -d)
-	cp manifest-beta.json $$STAGE/manifest.json
-	echo "→ Creating GitHub pre-release $$VERSION..."
-	gh release create $$VERSION \
+	@set -e; \
+	$(preflight); \
+	MANIFEST=manifest-beta.json; \
+	$(read_version); \
+	if gh release view "$$VERSION" >/dev/null 2>&1; then \
+		echo "Release $$VERSION already exists. Bump manifest-beta.json first."; exit 1; \
+	fi; \
+	if [ -z "$(NOTES)" ]; then \
+		read -p "Release notes [Beta release $$VERSION]: " INPUT_NOTES || true; \
+		FINAL_NOTES="$${INPUT_NOTES:-Beta release $$VERSION}"; \
+	else \
+		FINAL_NOTES="$(NOTES)"; \
+	fi; \
+	$(build_main_js); \
+	echo "→ Staging manifest-beta.json as manifest.json..."; \
+	STAGE=$$(mktemp -d); \
+	cp manifest-beta.json "$$STAGE/manifest.json"; \
+	echo "→ Creating GitHub pre-release $$VERSION..."; \
+	gh release create "$$VERSION" \
 		--title "$$VERSION (beta)" \
 		--prerelease \
 		--notes "$$FINAL_NOTES" \
-		main.js $$STAGE/manifest.json
-	rm -rf $$STAGE
-	echo "✓ Released $$VERSION (beta). BRAT users: 'Check for updates'."
+		main.js "$$STAGE/manifest.json"; \
+	rm -rf "$$STAGE"; \
+	echo "✓ Released $$VERSION beta."
 
 release-stable:
-	$(preflight)
-	VERSION=$$(node -p "require('./manifest.json').version")
-	if [ -z "$$VERSION" ]; then echo "Could not read version from manifest.json"; exit 1; fi
-	if gh release view $$VERSION >/dev/null 2>&1; then
-		echo "Release $$VERSION already exists. Bump manifest.json first."
-		exit 1
-	fi
-	if [ -z "$(NOTES)" ]; then
-		read -p "Release notes [Stable release $$VERSION]: " INPUT_NOTES || true
-		FINAL_NOTES="$${INPUT_NOTES:-Stable release $$VERSION}"
-	else
-		FINAL_NOTES="$(NOTES)"
-	fi
-	$(build_main_js)
-	echo "→ Creating GitHub release $$VERSION..."
-	gh release create $$VERSION \
+	@set -e; \
+	$(preflight); \
+	MANIFEST=manifest.json; \
+	$(read_version); \
+	if gh release view "$$VERSION" >/dev/null 2>&1; then \
+		echo "Release $$VERSION already exists. Bump manifest.json first."; exit 1; \
+	fi; \
+	if [ -z "$(NOTES)" ]; then \
+		read -p "Release notes [Stable release $$VERSION]: " INPUT_NOTES || true; \
+		FINAL_NOTES="$${INPUT_NOTES:-Stable release $$VERSION}"; \
+	else \
+		FINAL_NOTES="$(NOTES)"; \
+	fi; \
+	$(build_main_js); \
+	echo "→ Creating GitHub release $$VERSION..."; \
+	gh release create "$$VERSION" \
 		--title "$$VERSION" \
 		--notes "$$FINAL_NOTES" \
-		main.js manifest.json
-	echo "✓ Released $$VERSION (stable)."
+		main.js manifest.json; \
+	echo "✓ Released $$VERSION stable."
 
-.PHONY: help zip clean build audit outdated check-deps release-beta release-stable
+.PHONY: zip clean build release-beta release-stable

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,6 +1,6 @@
 {
   "id": "qmd-as-md-obsidian",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "description": "This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.",
   "name": "qmd as md",
   "author": "Daniel Borek",


### PR DESCRIPTION
## Why

Two issues from the last beta release attempt:

1. **`make release-beta` failed with "Could not read version from manifest-beta.json"** — generic message, no clue what actually went wrong. The reason was that macOS ships **GNU Make 3.81** (2006), which silently ignores `.ONESHELL` (added in 3.82, 2010). A recent refactor relied on `.ONESHELL` to keep variables alive between recipe lines; on 3.81 each line ran in its own shell, so `MANIFEST=…` was forgotten by the next line and `node -p` ran with the wrong arguments — its real error was swallowed.
2. **No documentation** for the failure modes we hit while shaking out the release flow (Make 3.81, BRAT asset naming, silent `gh` failures). Future-you would have to rediscover them.

## What changed

- **Drop `.ONESHELL`.** Recipes are `\`-joined into one shell invocation, portable to Make 3.81. Variables propagate, `set -e` works, `gh release create` runs against a real `main.js`.
- **`read_version` macro** captures Node's stderr and surfaces the real error (file not found, JSON parse error, missing `.version` field) instead of falling into a generic message.
- **README "Troubleshooting the release flow"** section documents:
  - wrong-cwd / missing manifest causing the empty-version failure;
  - the Make 3.81 vs `.ONESHELL` trap, with `brew install make` workaround;
  - BRAT rejecting a release when the manifest asset is not named literally `manifest.json`, and how to verify asset names;
  - silent `gh` failures on pre-`set -e` recipes.
- **README make-targets table** trimmed to match the current Makefile (`audit` / `outdated` / `check-deps` were removed in an earlier simplification — table was stale).
- Bumps `manifest-beta.json` to `0.1.0-rc.3` so the next `make release-beta` produces a fresh tag once this lands.

## Test plan

- [ ] `make release-beta` from repo root produces `0.1.0-rc.3` with `main.js` + `manifest.json` assets visible to BRAT.
- [ ] Run from a non-repo directory: clear "manifest-beta.json not found in <pwd>. Run make from the repo root." error.
- [ ] Temporarily corrupt `manifest-beta.json`: real Node syntax error printed, recipe aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the release Makefile for compatibility with older GNU Make versions while improving release robustness and documenting the release flow and failure modes.

New Features:
- Add reusable Makefile macros to preflight tool checks, build main.js, and read the version from a manifest with better error reporting.
- Allow passing release notes to release targets via an optional NOTES variable.

Bug Fixes:
- Make release targets compatible with macOS GNU Make 3.81 by avoiding reliance on .ONESHELL and ensuring variables propagate within single-shell recipes.
- Improve version-reading in release targets so missing or malformed manifests surface clear Node.js error messages instead of a generic failure.
- Ensure beta releases always upload a manifest asset literally named manifest.json so BRAT can detect the plugin correctly.

Enhancements:
- Harden release recipes with set -e, explicit tool presence checks, and verification that main.js is built before creating GitHub releases.
- Clarify beta and stable release completion messages and normalize their output wording.

Documentation:
- Update README make-targets table to reflect the current set of Make targets including release-beta and release-stable.
- Add detailed troubleshooting guidance for the release flow, covering manifest version errors, macOS Make behavior, BRAT asset naming issues, and silent gh failures.