### PR TITLE
feat: drop --to pdf, split into three engine-specific palette commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Three command-palette entries (all share the ribbon icon `file-output`, which is
 
 | Command | What it runs | When to use |
 |---------|--------------|-------------|
-| **Render Quarto to PDF (use YAML format)** | `quarto render <file>` | Document's YAML `format:` block decides the engine. Recommended default. |
+| **Render Quarto (use YAML format)** | `quarto render <file>` | Document's YAML `format:` block decides the output. If YAML targets a non-PDF format (e.g. `html`, `docx`), the file still renders but Obsidian's built-in viewer will not open it — the plugin shows a path notice. |
 | **Render Quarto to PDF (Typst engine)** | `quarto render <file> --to typst` | Force the Typst engine regardless of YAML. Use `QUARTO_TYPST` setting to pin a Typst binary. |
 | **Render Quarto to PDF (LaTeX engine)** | `quarto render <file> --to pdf` | Force the LaTeX engine (`lualatex`/`xelatex`/`pdflatex`). |
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ The main difference between this plugin and these other plugins is that this plu
 
 Available from **0.1.0-rc.1** via BRAT.
 
-- Command: **Render Quarto to PDF** (palette + ribbon icon `file-output`). Runs `quarto render <file>` on the active `.qmd` and lets the document's YAML decide the output format.
-- The plugin does **not** pass `--to pdf` — that flag is Quarto's LaTeX-engine PDF path and would force `lualatex`/`xelatex`/`pdflatex` to run even when you have declared a Typst format. Choose the engine in the document's YAML header:
-  - `format: pdf` — PDF via LaTeX.
-  - `format: typst` — PDF via Typst (use the `QUARTO_TYPST` setting to pin a custom Typst binary).
+Three command-palette entries (all share the ribbon icon `file-output`, which is bound to the YAML-driven variant):
+
+| Command | What it runs | When to use |
+|---------|--------------|-------------|
+| **Render Quarto to PDF (use YAML format)** | `quarto render <file>` | Document's YAML `format:` block decides the engine. Recommended default. |
+| **Render Quarto to PDF (Typst engine)** | `quarto render <file> --to typst` | Force the Typst engine regardless of YAML. Use `QUARTO_TYPST` setting to pin a Typst binary. |
+| **Render Quarto to PDF (LaTeX engine)** | `quarto render <file> --to pdf` | Force the LaTeX engine (`lualatex`/`xelatex`/`pdflatex`). |
+
+The CLI flag `--to pdf` is **Quarto's LaTeX path**, not a generic "any PDF" — that's why the engine-specific commands are split out. Pick the YAML-driven one if your `.qmd` already declares the format you want; pick an explicit engine to override per-render without touching the file.
 - Setting **Open Compiled PDF in Obsidian** (off by default):
   - **Off** — render finishes, notice shows the PDF path. Open it however you want.
   - **On** — rendered PDF opens in a vertical split on the right via Obsidian's built-in PDF viewer. Source tab keeps focus.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The main difference between this plugin and these other plugins is that this plu
 ## Version History
 
 ### 0.1.0-rc.1 (beta — BRAT only)
-- Added **Render Quarto to PDF** command and ribbon icon. Runs `quarto render <file> --to pdf` on the active `.qmd` file.
+- Added **Render Quarto to PDF** command and ribbon icon. Runs `quarto render <file>` on the active `.qmd` file (output format driven by the document's YAML — `format: typst` for Typst, `format: pdf` for LaTeX).
 - Added **"Open Compiled PDF in Obsidian"** setting toggle. When enabled, the rendered PDF opens inside Obsidian using the built-in PDF viewer.
 - PDF opens in a vertical split to the right of the source `.qmd`, so the source tab is no longer replaced.
 - Re-running the render reuses the existing PDF tab (reloads the file in place) instead of stacking new tabs.
@@ -51,7 +51,10 @@ The main difference between this plugin and these other plugins is that this plu
 
 Available from **0.1.0-rc.1** via BRAT.
 
-- Command: **Render Quarto to PDF** (palette + ribbon icon `file-output`). Runs `quarto render <file> --to pdf` on the active `.qmd`.
+- Command: **Render Quarto to PDF** (palette + ribbon icon `file-output`). Runs `quarto render <file>` on the active `.qmd` and lets the document's YAML decide the output format.
+- The plugin does **not** pass `--to pdf` — that flag is Quarto's LaTeX-engine PDF path and would force `lualatex`/`xelatex`/`pdflatex` to run even when you have declared a Typst format. Choose the engine in the document's YAML header:
+  - `format: pdf` — PDF via LaTeX.
+  - `format: typst` — PDF via Typst (use the `QUARTO_TYPST` setting to pin a custom Typst binary).
 - Setting **Open Compiled PDF in Obsidian** (off by default):
   - **Off** — render finishes, notice shows the PDF path. Open it however you want.
   - **On** — rendered PDF opens in a vertical split on the right via Obsidian's built-in PDF viewer. Source tab keeps focus.

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,7 +273,7 @@ export default class QmdAsMdPlugin extends Plugin {
 
       const quartoProcess = spawn(
         this.settings.quartoPath,
-        ['render', filePath, '--to', 'pdf'],
+        ['render', filePath],
         { cwd: workingDir, env: envVars }
       );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,35 +71,9 @@ export default class QmdAsMdPlugin extends Plugin {
         if (file) await this.renderPdf(file);
       });
 
-      this.addCommand({
-        id: 'render-quarto-pdf',
-        name: 'Render Quarto to PDF (use YAML format)',
-        icon: 'file-output',
-        callback: async () => {
-          const file = this.getActiveQuartoFile();
-          if (file) await this.renderPdf(file);
-        },
-      });
-
-      this.addCommand({
-        id: 'render-quarto-pdf-typst',
-        name: 'Render Quarto to PDF (Typst engine)',
-        icon: 'file-output',
-        callback: async () => {
-          const file = this.getActiveQuartoFile();
-          if (file) await this.renderPdf(file, 'typst');
-        },
-      });
-
-      this.addCommand({
-        id: 'render-quarto-pdf-latex',
-        name: 'Render Quarto to PDF (LaTeX engine)',
-        icon: 'file-output',
-        callback: async () => {
-          const file = this.getActiveQuartoFile();
-          if (file) await this.renderPdf(file, 'pdf');
-        },
-      });
+      this.registerRenderCommand('render-quarto-pdf', 'Render Quarto (use YAML format)');
+      this.registerRenderCommand('render-quarto-pdf-typst', 'Render Quarto to PDF (Typst engine)', 'typst');
+      this.registerRenderCommand('render-quarto-pdf-latex', 'Render Quarto to PDF (LaTeX engine)', 'pdf');
 
       console.log('Commands added');
     } catch (error) {
@@ -147,6 +121,18 @@ export default class QmdAsMdPlugin extends Plugin {
 
   pdfPathFor(qmdFile: TFile): string {
     return qmdFile.path.replace(/\.qmd$/i, '.pdf');
+  }
+
+  registerRenderCommand(id: string, name: string, toFormat?: 'pdf' | 'typst') {
+    this.addCommand({
+      id,
+      name,
+      icon: 'file-output',
+      callback: async () => {
+        const file = this.getActiveQuartoFile();
+        if (file) await this.renderPdf(file, toFormat);
+      },
+    });
   }
 
   registerQmdExtension() {
@@ -284,13 +270,16 @@ export default class QmdAsMdPlugin extends Plugin {
         envVars.QUARTO_TYPST = this.settings.quartoTypst.trim();
       }
 
-      const engineLabel = toFormat === 'typst' ? 'Typst' : toFormat === 'pdf' ? 'LaTeX' : 'YAML format';
-      new Notice(`Rendering Quarto to PDF (${engineLabel})...`);
+      const engineLabel = toFormat === 'typst' ? 'Typst' : toFormat === 'pdf' ? 'LaTeX' : 'use YAML format';
+      new Notice(`Rendering Quarto (${engineLabel})...`);
 
-      const pdfVaultPath = this.pdfPathFor(file);
+      // Best-guess path used for the pre-render leaf-capture (so we can
+      // reuse an existing PDF tab on recompile). The authoritative path
+      // comes from quarto's "Output created:" stdout line, parsed below.
+      const guessedPdfPath = this.pdfPathFor(file);
       const existingLeaf = this.app.workspace
         .getLeavesOfType('pdf')
-        .find((l) => (l.view as any)?.file?.path === pdfVaultPath);
+        .find((l) => (l.view as any)?.file?.path === guessedPdfPath);
 
       const args = ['render', filePath];
       if (toFormat) args.push('--to', toFormat);
@@ -300,9 +289,16 @@ export default class QmdAsMdPlugin extends Plugin {
         env: envVars,
       });
 
+      let detectedOutputBasename: string | null = null;
+
       quartoProcess.stdout?.on('data', (data: Buffer) => {
+        const output = data.toString();
         if (this.settings.emitCompilationLogs) {
-          console.log(`Quarto Render Output: ${data.toString()}`);
+          console.log(`Quarto Render Output: ${output}`);
+        }
+        const match = output.match(/Output created:\s*(.+?)\s*$/m);
+        if (match) {
+          detectedOutputBasename = path.basename(match[1].trim());
         }
       });
 
@@ -318,17 +314,28 @@ export default class QmdAsMdPlugin extends Plugin {
           return;
         }
 
-        const pdfTFile = await this.waitForVaultFile(pdfVaultPath);
+        const sourceDir = file.parent?.path ?? '';
+        const outputVaultPath = detectedOutputBasename
+          ? (sourceDir ? `${sourceDir}/${detectedOutputBasename}` : detectedOutputBasename)
+          : guessedPdfPath;
 
-        if (!pdfTFile) {
+        const outputTFile = await this.waitForVaultFile(outputVaultPath);
+
+        if (!outputTFile) {
           new Notice(
-            `Quarto rendered, but ${pdfVaultPath} did not appear in the vault within the timeout. Check Quarto's output-dir or vault sync.`
+            `Quarto rendered, but ${outputVaultPath} did not appear in the vault within the timeout. Check Quarto's output-dir or vault sync.`
           );
           return;
         }
 
-        if (!this.settings.openPdfInObsidian) {
-          new Notice(`PDF rendered: ${pdfVaultPath}`);
+        const isPdf = outputVaultPath.toLowerCase().endsWith('.pdf');
+
+        if (!this.settings.openPdfInObsidian || !isPdf) {
+          new Notice(
+            isPdf
+              ? `PDF rendered: ${outputVaultPath}`
+              : `Rendered: ${outputVaultPath} (Obsidian's built-in viewer only handles PDFs).`
+          );
           return;
         }
 
@@ -336,13 +343,13 @@ export default class QmdAsMdPlugin extends Plugin {
           const leaf = existingLeaf?.parent != null
             ? existingLeaf
             : this.app.workspace.getLeaf('split', 'vertical');
-          await leaf.openFile(pdfTFile, { active: false });
+          await leaf.openFile(outputTFile, { active: false });
           this.app.workspace.revealLeaf(leaf);
-          new Notice(`Opened ${pdfVaultPath}`);
+          new Notice(`Opened ${outputVaultPath}`);
         } catch (err) {
           console.error('Failed to open PDF in Obsidian:', err);
           new Notice(
-            `PDF rendered at ${pdfVaultPath}, but Obsidian could not open it (no PDF viewer registered?).`
+            `PDF rendered at ${outputVaultPath}, but Obsidian could not open it (no PDF viewer registered?).`
           );
         }
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,11 +73,31 @@ export default class QmdAsMdPlugin extends Plugin {
 
       this.addCommand({
         id: 'render-quarto-pdf',
-        name: 'Render Quarto to PDF',
+        name: 'Render Quarto to PDF (use YAML format)',
         icon: 'file-output',
         callback: async () => {
           const file = this.getActiveQuartoFile();
           if (file) await this.renderPdf(file);
+        },
+      });
+
+      this.addCommand({
+        id: 'render-quarto-pdf-typst',
+        name: 'Render Quarto to PDF (Typst engine)',
+        icon: 'file-output',
+        callback: async () => {
+          const file = this.getActiveQuartoFile();
+          if (file) await this.renderPdf(file, 'typst');
+        },
+      });
+
+      this.addCommand({
+        id: 'render-quarto-pdf-latex',
+        name: 'Render Quarto to PDF (LaTeX engine)',
+        icon: 'file-output',
+        callback: async () => {
+          const file = this.getActiveQuartoFile();
+          if (file) await this.renderPdf(file, 'pdf');
         },
       });
 
@@ -247,7 +267,7 @@ export default class QmdAsMdPlugin extends Plugin {
     }
   }
 
-  async renderPdf(file: TFile) {
+  async renderPdf(file: TFile, toFormat?: 'pdf' | 'typst') {
     try {
       const abstractFile = this.app.vault.getAbstractFileByPath(file.path);
       if (!abstractFile || !(abstractFile instanceof TFile)) {
@@ -264,18 +284,21 @@ export default class QmdAsMdPlugin extends Plugin {
         envVars.QUARTO_TYPST = this.settings.quartoTypst.trim();
       }
 
-      new Notice('Rendering Quarto to PDF...');
+      const engineLabel = toFormat === 'typst' ? 'Typst' : toFormat === 'pdf' ? 'LaTeX' : 'YAML format';
+      new Notice(`Rendering Quarto to PDF (${engineLabel})...`);
 
       const pdfVaultPath = this.pdfPathFor(file);
       const existingLeaf = this.app.workspace
         .getLeavesOfType('pdf')
         .find((l) => (l.view as any)?.file?.path === pdfVaultPath);
 
-      const quartoProcess = spawn(
-        this.settings.quartoPath,
-        ['render', filePath],
-        { cwd: workingDir, env: envVars }
-      );
+      const args = ['render', filePath];
+      if (toFormat) args.push('--to', toFormat);
+
+      const quartoProcess = spawn(this.settings.quartoPath, args, {
+        cwd: workingDir,
+        env: envVars,
+      });
 
       quartoProcess.stdout?.on('data', (data: Buffer) => {
         if (this.settings.emitCompilationLogs) {


### PR DESCRIPTION
## Why

Two related changes around how `quarto render` is invoked:

1. **`--to pdf` was hard-coded.** That flag is Quarto's *LaTeX-engine* PDF path — it forces `luahbtex`/`xelatex`/`pdflatex` to run even when the document's YAML declares `format: typst`. Users with Typst-styled `.qmd` files saw LaTeX being invoked despite their YAML.
2. **One ambiguous command.** "Render Quarto to PDF" gave the user no control over which engine runs without editing YAML.

## What changed

- `renderPdf(file, toFormat?)` takes an optional engine. No flag passed means YAML decides. `'typst'` and `'pdf'` map to `--to typst` and `--to pdf`.
- Three palette commands cover the full intent matrix:

  | Palette name | Spawn args | Use |
  |---|---|---|
  | Render Quarto to PDF (use YAML format) | `quarto render <file>` | YAML decides (recommended default) |
  | Render Quarto to PDF (Typst engine) | `--to typst` | Force Typst |
  | Render Quarto to PDF (LaTeX engine) | `--to pdf` | Force LaTeX |

- Ribbon icon stays bound to the YAML-driven variant. Palette + Commander handle the rest.
- Progress notice names the engine in use ("Rendering Quarto to PDF (Typst)…") so the user can confirm which command they invoked.
- README rewritten to match: comparison table, explicit note that `--to pdf` ≠ "any PDF", how to pin a Typst binary via `QUARTO_TYPST`.

## Test plan

- [ ] On a `.qmd` with `format: typst` in YAML, run **Render Quarto to PDF (use YAML format)** → only the typst binary spawns, no `luahbtex`.
- [ ] Same file, run **Render Quarto to PDF (LaTeX engine)** → LaTeX engine runs regardless of YAML.
- [ ] PDF still opens in the right split / reuses existing tab when **Open Compiled PDF in Obsidian** is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Quarto PDF rendering to respect document YAML by default and add explicit engine-specific commands.

New Features:
- Introduce separate commands to render Quarto documents with Typst or LaTeX engines in addition to the YAML-driven default command.

Enhancements:
- Update the generic Quarto PDF render command to defer output format selection to the document's YAML instead of forcing the LaTeX PDF path.
- Improve user notices during rendering to indicate which engine or YAML-driven format is being used.
- Revise README documentation to describe the three rendering commands, their behavior, and how engine selection works.