### PR TITLE
fix(preview): detect disabled webviewer + README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ This plugin originated in 2022 as a minimal change to a now-archived project by 
 
 Once installed, `.qmd` files open in Obsidian's Markdown editor automatically.
 
----
-
-## To-Do List
-
-- [x] Use Obsidian 1.8's web preview to enable seamless in-app previews. *(toggle in settings — see "Live preview" section.)*
-- [ ] Recognize `{language}` for code block syntax highlighting.
-- [ ] Add CSS support for callout blocks.
-- [ ] Enable the creation of new QMD files.
-- [x] Add a render command. *(0.1.0-rc.1 — render to PDF, open inside Obsidian.)*
-
 To enable linking with Quarto files, ensure the **"Detect all file extensions"** toggle is activated in the `Files & Links` section of Obsidian settings.
 
 ### Quarto preview
@@ -50,22 +40,6 @@ The CLI flag `--to pdf` is **Quarto's LaTeX path**, not a generic "any PDF" — 
 
 #### Setting: Open Compiled PDF in Obsidian
 
-
-## Live preview (beta)
-
-The **Toggle Quarto Preview** command (palette + ribbon icon `eye`, default hotkey `Ctrl+Shift+P`) spawns `quarto preview` on the active `.qmd`, which runs a live HTTP server that re-renders on every save.
-
-Setting **Open Quarto preview in Obsidian** decides where the preview URL lands:
-
-- **On** (default) — uses Obsidian 1.8's built-in `webviewer` view to render the live preview in a tab inside Obsidian. No window switching; the preview re-renders in place as you save the source.
-- **Off** — opens the preview URL in your default external browser (via `window.open`, which Electron routes through `shell.openExternal`).
-
-Either way, the underlying `quarto preview` process keeps running until you toggle the command again — the toggle controls where the URL is opened, not the server's behaviour.
-
----
-
-## Enhancing Quarto File Integration in Obsidian
-=======
 Off by default.
 
 - **Off** — render finishes, notice shows the PDF path. Open it however you want.
@@ -77,6 +51,21 @@ Re-running the render reuses the existing PDF tab — no tab stacking.
 
 - The `.qmd` source must live inside the vault (the rendered `.pdf` lands next to it; Obsidian only opens vault files).
 - Custom `output-dir` in `_quarto.yml` is not yet handled — the plugin looks for `<basename>.pdf` next to the source.
+
+### Live preview
+
+*(Since 0.2.)*
+
+The **Toggle Quarto Preview** command (palette + ribbon icon `eye`, default hotkey `Ctrl+Shift+P`) spawns `quarto preview` on the active `.qmd`, which runs a live HTTP server that re-renders on every save.
+
+Setting **Open Quarto preview in Obsidian** decides where the preview URL lands:
+
+- **On** (default) — uses Obsidian 1.8's built-in `webviewer` view to render the live preview in a tab inside Obsidian. Requires the **Web viewer** core plugin to be enabled (Settings → Core plugins). The preview re-renders in place as you save the source.
+- **Off** — opens the preview URL in your default external browser (via `window.open`, which Electron routes through `shell.openExternal`).
+
+If the Web viewer core plugin is disabled while the toggle is on, the plugin shows a notice instead of silently failing.
+
+Either way, the underlying `quarto preview` process keeps running until you toggle the command again — the toggle controls where the URL is opened, not the server's behaviour.
 
 ## Alternatives
 
@@ -137,7 +126,7 @@ div[data-path$='.json'] {
 
 ## Roadmap
 
-- [ ] Use Obsidian 1.8's web preview to enable seamless in-app previews.
+- [x] Use Obsidian 1.8's web preview to enable seamless in-app previews. *(Shipped in 0.2.0-rc.1 — toggle in settings.)*
 - [ ] Recognize `{language}` for code block syntax highlighting.
 - [ ] Add CSS support for callout blocks.
 - [ ] Enable the creation of new QMD files.

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ export default class QmdAsMdPlugin extends Plugin {
     return qmdFile.path.replace(/\.qmd$/i, '.pdf');
   }
 
-  openPreviewUrl(url: string) {
+  async openPreviewUrl(url: string) {
     new Notice(`Preview available at ${url}`);
 
     if (!this.settings.previewInObsidian) {
@@ -135,13 +135,44 @@ export default class QmdAsMdPlugin extends Plugin {
       return;
     }
 
-    const leaf = this.app.workspace.getLeaf('tab');
-    leaf.setViewState({
-      type: 'webviewer',
-      active: true,
-      state: { url },
-    });
-    this.app.workspace.revealLeaf(leaf);
+    // The "Web viewer" core plugin (Obsidian 1.8+) registers the
+    // 'webviewer' view type. If the user has it disabled, setViewState
+    // silently fails / leaves an empty leaf, and the user is left
+    // wondering why nothing opened. Detect and report instead.
+    const internalPlugins = (this.app as any).internalPlugins;
+    const webviewerOn =
+      internalPlugins?.getEnabledPluginById?.('webviewer') != null ||
+      internalPlugins?.plugins?.webviewer?.enabled === true;
+
+    if (!webviewerOn) {
+      new Notice(
+        'Obsidian core plugin "Web viewer" is disabled — cannot show preview in-app. ' +
+          'Enable it in Settings → Core plugins, or turn off "Open Quarto preview in Obsidian" ' +
+          'to use your external browser instead.',
+        10000
+      );
+      console.warn(
+        '[qmd-as-md] webviewer core plugin disabled; preview URL was:',
+        url
+      );
+      return;
+    }
+
+    try {
+      const leaf = this.app.workspace.getLeaf('tab');
+      await leaf.setViewState({
+        type: 'webviewer',
+        active: true,
+        state: { url },
+      });
+      this.app.workspace.revealLeaf(leaf);
+    } catch (err) {
+      console.error('[qmd-as-md] Failed to open preview in webviewer:', err);
+      new Notice(
+        `Could not open preview in Obsidian's web viewer. Falling back to external browser.`
+      );
+      window.open(url, '_blank');
+    }
   }
 
   registerRenderCommand(id: string, name: string, toFormat?: 'pdf' | 'typst') {


### PR DESCRIPTION
## Why

Reported after testing rc.x: the **Open Quarto preview in Obsidian** toggle was on, but the preview kept appearing to "open externally." Root cause: when Obsidian's **Web viewer** core plugin (1.8+) is disabled, `leaf.setViewState({ type: 'webviewer', ... })` silently no-ops — the view type is not registered, the new tab stays empty, and the user is left wondering what happened. The Quarto server is running, the URL is correct, but nothing visibly opens in-app.

A separate but related issue: after the rebase onto main, the README ended up with a `=======` conflict marker, orphaned PDF-setting docs, and a duplicate To-Do/Roadmap pair.

## What changed

1. `openPreviewUrl(url)` now checks `app.internalPlugins` for the `webviewer` entry before calling `setViewState`. If disabled, shows an actionable notice ("Enable Web viewer in Settings → Core plugins, or turn off the in-app toggle") and logs a warning with the preview URL. No more silent failure.
2. `setViewState` is now awaited inside a try/catch — any genuine API failure falls back to `window.open` with a notice instead of leaving an empty leaf.
3. README cleanup: removed the conflict marker, restored the orphaned PDF setting body under its header, moved the Live preview docs into the Usage tree as a sibling of the other usage subsections, dropped the duplicate To-Do list, ticked the Roadmap entry with a `0.2.0-rc.1` marker, and added a one-line note that in-app preview requires the Web viewer core plugin.

## Test plan

- [ ] Disable **Web viewer** core plugin, run **Toggle Quarto Preview** with the in-app toggle on → notice appears explaining the cause; no empty tab opens; URL is logged to console.
- [ ] Enable Web viewer, re-run → preview opens in an Obsidian tab.
- [ ] Turn the in-app toggle off, re-run → preview opens in the default external browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle failures when opening Quarto live preview in Obsidian and clarify Web viewer requirements in documentation.

Bug Fixes:
- Prevent silent failures when the Web viewer core plugin is disabled by detecting its status before opening in-app previews and falling back to notices and external browser where needed.
- Ensure errors from setting the webviewer view state surface to users and fall back to opening the preview externally instead of leaving an empty tab.

Documentation:
- Clarify that in-app live preview requires the Web viewer core plugin, restructure the Live preview section under Usage, and clean up duplicated or conflicted README content including roadmap updates.