### PR TITLE
feat: route PDF previews to native PDF viewer (no PDF.js wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ Re-running the render reuses the existing PDF tab — no tab stacking.
 
 The **Toggle Quarto Preview** command (palette + ribbon icon `eye`, default hotkey `Ctrl+Shift+P`) spawns `quarto preview` on the active `.qmd`, which runs a live HTTP server that re-renders on every save.
 
-Setting **Open Quarto preview in Obsidian** decides where the preview URL lands:
+Setting **Open Quarto preview in Obsidian** decides where the preview lands:
 
-- **On** (default) — uses Obsidian 1.8's built-in `webviewer` view to render the live preview in a tab inside Obsidian. Requires the **Web viewer** core plugin to be enabled (Settings → Core plugins). The preview re-renders in place as you save the source.
-- **Off** — opens the preview URL in your default external browser (via `window.open`, which Electron routes through `shell.openExternal`).
+- **On** (default):
+  - **PDF outputs** (e.g. `format: typst`, `format: pdf`) open in Obsidian's **native PDF viewer** in a right split. Each compile from the running preview refreshes the same tab — no Quarto-served PDF.js wrapper page. The HTTP server keeps running in the background, but the URL is not opened; instead, a notice reports the server URL for reference.
+  - **Non-PDF outputs** (HTML, etc.) open in Obsidian 1.8's built-in `webviewer` view. Requires the **Web viewer** core plugin to be enabled (Settings → Core plugins). The preview re-renders in place as you save the source.
+- **Off**: the preview URL opens in your default external browser (via `window.open`, which Electron routes through `shell.openExternal`).
 
-If the Web viewer core plugin is disabled while the toggle is on, the plugin shows a notice instead of silently failing.
+If the Web viewer core plugin is disabled while the toggle is on for a non-PDF preview, the plugin shows a notice instead of silently failing.
 
-Either way, the underlying `quarto preview` process keeps running until you toggle the command again — the toggle controls where the URL is opened, not the server's behaviour.
+Either way, the underlying `quarto preview` process keeps running until you toggle the command again — the toggle controls where the output is shown, not the server's behaviour.
 
 ## Alternatives
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
   App,
   Setting,
   FileSystemAdapter,
+  WorkspaceLeaf,
 } from 'obsidian';
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
@@ -125,6 +126,35 @@ export default class QmdAsMdPlugin extends Plugin {
     return qmdFile.path.replace(/\.qmd$/i, '.pdf');
   }
 
+  // Open (or reuse) a leaf showing the given vault-relative PDF path in
+  // Obsidian's native PDF viewer. Returns the leaf so callers can keep
+  // refreshing it on subsequent preview compiles.
+  async openOrRefreshPdfPreview(
+    vaultPath: string,
+    existingLeaf: WorkspaceLeaf | null
+  ): Promise<WorkspaceLeaf | null> {
+    const pdfTFile = await this.waitForVaultFile(vaultPath);
+    if (!pdfTFile) {
+      new Notice(
+        `Quarto preview produced ${vaultPath} but it did not appear in the vault within the timeout.`
+      );
+      return null;
+    }
+    try {
+      const leaf =
+        existingLeaf?.parent != null
+          ? existingLeaf
+          : this.app.workspace.getLeaf('split', 'vertical');
+      await leaf.openFile(pdfTFile, { active: false });
+      this.app.workspace.revealLeaf(leaf);
+      return leaf;
+    } catch (err) {
+      console.error('[qmd-as-md] Failed to open PDF preview in native viewer:', err);
+      new Notice(`Could not open ${vaultPath} in Obsidian's PDF viewer.`);
+      return null;
+    }
+  }
+
   async openPreviewUrl(url: string) {
     new Notice(`Preview available at ${url}`);
 
@@ -235,6 +265,8 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       let previewUrl: string | null = null;
+      let pdfPreviewLeaf: WorkspaceLeaf | null = null;
+      let pdfPreviewPath: string | null = null;
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
       // not strictly content/error, so log by line prefix instead of
@@ -247,11 +279,37 @@ export default class QmdAsMdPlugin extends Plugin {
           } else if (this.settings.emitCompilationLogs) {
             console.log(`Quarto Preview: ${line}`);
           }
+
+          // Detect "Output created: <path>" — quarto prints this on every
+          // compile in preview mode. If the output is a PDF, route to
+          // Obsidian's native PDF viewer rather than the webviewer page
+          // Quarto serves at /web/viewer.html. Subsequent compiles refresh
+          // the same leaf so live reload still works.
+          const outMatch = line.match(/Output created:\s*(.+?)\s*$/);
+          if (outMatch && /\.pdf$/i.test(outMatch[1].trim()) && this.settings.previewInObsidian) {
+            const outBasename = path.basename(outMatch[1].trim());
+            const sourceDir = file.parent?.path ?? '';
+            const vaultPath = sourceDir ? `${sourceDir}/${outBasename}` : outBasename;
+            pdfPreviewPath = vaultPath;
+            // Fire-and-forget; errors logged inside.
+            this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf).then((leaf) => {
+              pdfPreviewLeaf = leaf ?? pdfPreviewLeaf;
+            });
+            continue;
+          }
+
           if (!previewUrl && line.includes('Browse at')) {
             const match = line.match(/Browse at\s+(http:\/\/[^\s]+)/);
             if (match && match[1]) {
               previewUrl = match[1];
-              this.openPreviewUrl(previewUrl);
+              // If we already opened a native PDF preview, skip the
+              // webviewer URL — Quarto's PDF.js wrapper would just be
+              // a worse version of the same content.
+              if (pdfPreviewPath) {
+                new Notice(`PDF preview opened natively. Server URL: ${previewUrl}`);
+              } else {
+                this.openPreviewUrl(previewUrl);
+              }
             }
           }
         }


### PR DESCRIPTION
## Why

When the active `.qmd` declares a PDF format (`format: typst`, `format: pdf`, etc.), `quarto preview` serves the rendered PDF wrapped in its own PDF.js viewer at a URL like `http://localhost:7488/web/viewer.html?file=…`. The previous in-Obsidian toggle routed that URL into Obsidian's webviewer view, so the user ended up looking at PDF.js running inside Obsidian — strictly worse than Obsidian's native PDF viewer.

Reported symptom: "the output pdf after merging is still opening in http://localhost:7488/web/viewer.html" — the URL was correctly opened in Obsidian, but as PDF.js rather than as a PDF.

## What changed

- Parse `Output created: <path>` from `quarto preview`'s stdout/stderr (it emits this on every compile in preview mode).
- If the output is a `.pdf` and the **Open Quarto preview in Obsidian** toggle is on, route to `openOrRefreshPdfPreview()` which opens (or reuses) a leaf showing the file in Obsidian's native PDF viewer.
- Each subsequent compile from the running preview process calls the same helper, which calls `leaf.openFile()` on the existing leaf — live reload preserved, just without the PDF.js wrapper page.
- The `Browse at <url>` line is still parsed, but if a native PDF preview is already open the webviewer URL is skipped (a notice reports the server URL for reference).
- Non-PDF preview outputs (HTML, etc.) continue to use the existing webviewer-or-external-browser path.
- README's Live preview section now documents the PDF vs HTML branch.

## Test plan

- [ ] `.qmd` with `format: typst` + **Toggle Quarto Preview** with in-app toggle on → PDF opens in Obsidian's native PDF viewer in a right split; editing the source and saving reloads the same tab.
- [ ] `.qmd` with `format: html` + same command → preview opens in webviewer as before.
- [ ] In-app toggle off + either format → URL opens in default external browser.
- [ ] Disable **Web viewer** core plugin, run on a non-PDF format → notice fires as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route Quarto PDF preview outputs to Obsidian’s native PDF viewer instead of the Quarto-served PDF.js page while preserving live-reload behavior.

New Features:
- Add native PDF preview support by opening or reusing an Obsidian PDF-viewer leaf for Quarto-generated PDF outputs during preview.

Enhancements:
- Adjust preview URL handling to skip opening the Quarto webviewer when a native PDF preview is already active, showing a notice with the server URL instead.
- Document the different routing behavior for PDF versus non-PDF outputs in the Live preview section of the README.