### PR TITLE
fix(preview): pass --no-browse to stop double-opening

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -259,10 +259,15 @@ export default class QmdAsMdPlugin extends Plugin {
         console.log(`QUARTO_TYPST set to: ${envVars.QUARTO_TYPST}`);
       }
 
-      const quartoProcess = spawn(this.settings.quartoPath, ['preview', filePath], {
-        cwd: workingDir,
-        env: envVars,
-      });
+      // --no-browse stops Quarto from auto-opening the preview URL in
+      // the default system browser. Without it the plugin's own
+      // open-in-Obsidian/open-external logic competes with Quarto's,
+      // and the user sees two windows (Obsidian leaf + external tab).
+      const quartoProcess = spawn(
+        this.settings.quartoPath,
+        ['preview', filePath, '--no-browse'],
+        { cwd: workingDir, env: envVars }
+      );
 
       let previewUrl: string | null = null;
       let pdfPreviewLeaf: WorkspaceLeaf | null = null;


### PR DESCRIPTION
## Why

Reported after rc.x install: with **Open Quarto preview in Obsidian** on, the preview opened **both** inside Obsidian (correctly, in the native PDF viewer / webviewer) **and** in the user's default external browser. The toggle was working, but Quarto was also opening a browser tab on its own.

## Cause

`quarto preview` opens the preview URL in the system default browser by default. The plugin was not telling it to stop, so Quarto's auto-open ran in parallel with the plugin's own open-in-Obsidian routing.

## Fix

Add `--no-browse` to the `quarto preview` spawn args. Quarto still prints `Browse at <url>` (the plugin parses that to find the URL) and still runs the live-reload HTTP server — it just stops launching a browser. The plugin's toggle now solely decides where the preview is shown:

- **On** → Obsidian-only (native PDF viewer for PDF outputs, webviewer for HTML, etc.).
- **Off** → external browser only.

No more competing windows.

## Test plan

- [ ] Toggle on, run preview on `format: typst` doc → PDF opens in Obsidian native viewer; no extra external browser window.
- [ ] Toggle on, run preview on `format: html` doc → opens in webviewer; no external window.
- [ ] Toggle off, run preview → external browser only; nothing opens in Obsidian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Stop duplicate preview windows by adding the --no-browse flag to the Quarto preview command so only the plugin’s routing controls where the preview opens.