### PR TITLE
docs: align preview setting description; minor PDF-leaf reuse fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,12 @@ export default class QmdAsMdPlugin extends Plugin {
   // Open (or reuse) a leaf showing the given vault-relative PDF path in
   // Obsidian's native PDF viewer. Returns the leaf so callers can keep
   // refreshing it on subsequent preview compiles.
+  //
+  // Leaf-resolution order:
+  //   1. Caller's captured ref, if still attached to the workspace.
+  //   2. Any open 'pdf' leaf already showing this exact file (user may
+  //      have opened it manually, or renderPdf may have opened it).
+  //   3. New vertical split.
   async openOrRefreshPdfPreview(
     vaultPath: string,
     existingLeaf: WorkspaceLeaf | null
@@ -141,10 +147,13 @@ export default class QmdAsMdPlugin extends Plugin {
       return null;
     }
     try {
-      const leaf =
+      const reusable =
         existingLeaf?.parent != null
           ? existingLeaf
-          : this.app.workspace.getLeaf('split', 'vertical');
+          : this.app.workspace
+              .getLeavesOfType('pdf')
+              .find((l) => (l.view as any)?.file?.path === pdfTFile.path) ?? null;
+      const leaf = reusable ?? this.app.workspace.getLeaf('split', 'vertical');
       await leaf.openFile(pdfTFile, { active: false });
       this.app.workspace.revealLeaf(leaf);
       return leaf;
@@ -577,7 +586,11 @@ class QmdSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Open Quarto preview in Obsidian')
       .setDesc(
-        'Use Obsidian 1.8\'s built-in web viewer (webviewer view) for the live Quarto preview server. When off, the preview URL opens in your default external browser instead.'
+        'When on: PDF previews (format: typst / pdf) open in Obsidian\'s native PDF viewer; ' +
+          'non-PDF previews (HTML, etc.) open in Obsidian 1.8\'s built-in web viewer ' +
+          '(requires the "Web viewer" core plugin enabled in Settings → Core plugins). ' +
+          'Live reload from the running quarto preview is preserved in both cases. ' +
+          'When off, the preview URL opens in your default external browser instead.'
       )
       .addToggle((toggle) =>
         toggle


### PR DESCRIPTION
## Summary

- **Setting description** for "Open Quarto preview in Obsidian" rewritten to match actual behaviour. Old text claimed the webviewer was used for all preview content; in reality PDF outputs (`format: typst`/`pdf`) go to Obsidian's native PDF viewer (since PR #12) and only non-PDF outputs use the webviewer. New text spells out both branches and the Web viewer core-plugin requirement.

- **`openOrRefreshPdfPreview`** now falls back to `getLeavesOfType('pdf')` + path-match when the caller's captured leaf reference is detached. Same pattern `renderPdf` already uses, so the preview helper reuses a leaf opened by an explicit render command (or one the user opened manually) instead of stacking a fresh split.

## Manual API review (notes for the record)

While editing the description I re-read the recent changes against Obsidian's public API. Findings:

- `workspace.getLeaf('split', 'vertical')`, `getLeaf('tab')`, `setViewState({ type: 'webviewer', state: { url } })`, `leaf.openFile(file, { active: false })`, `workspace.revealLeaf` — all canonical and used correctly.
- `setViewState` is awaited inside a try/catch that falls back to `window.open` — handles the case where the registered view's state schema changes between Obsidian versions.
- `app.internalPlugins` access is `(this.app as any)` — undocumented but the only way to detect the Web viewer core plugin. Two access paths (`getEnabledPluginById` and `plugins[id].enabled`) cover both Obsidian 1.5- and 1.8-era shapes.
- ChildProcess lifecycle: tracked per-file in `activePreviewProcesses` map, `kill()` called from `stopPreview`, `stopAllPreviews`, and `onunload`. `close` listener removes from the map. No leaks.
- `loadSettings` uses `Object.assign({}, DEFAULT_SETTINGS, …)` — new fields seed correctly for users upgrading from older versions.
- Minor non-blocker: stdout/stderr handlers split each `data` chunk independently. If Quarto emits a partial line across two data events the regex misses. Not observed in practice; line-buffering can be added later if needed.

No anti-patterns or correctness bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify how Obsidian handles Quarto previews and improve reuse of existing PDF preview panes when refreshing previews.

Bug Fixes:
- Ensure PDF preview refresh reuses an existing PDF leaf showing the same file when the original leaf reference is no longer attached, avoiding unnecessary new splits.

Enhancements:
- Document the different handling paths for PDF vs non-PDF Quarto previews and the requirement for the Web viewer core plugin in the related setting description.