### PR TITLE
fix(preview): tab spam on save — serialize PDF leaf updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,15 @@ export default class QmdAsMdPlugin extends Plugin {
               .getLeavesOfType('pdf')
               .find((l) => (l.view as any)?.file?.path === pdfTFile.path) ?? null;
       const leaf = reusable ?? this.app.workspace.getLeaf('split', 'vertical');
-      await leaf.openFile(pdfTFile, { active: false });
+      // Skip the openFile call when the leaf already shows this file —
+      // calling openFile in that case is harmless for the file display
+      // but still triggers a reveal/focus shuffle the user does not want.
+      // Obsidian's PDF viewer picks up the file rewrite via its own
+      // mtime watcher, so live reload still works without our help.
+      const currentFile = (leaf.view as any)?.file;
+      if (!currentFile || currentFile.path !== pdfTFile.path) {
+        await leaf.openFile(pdfTFile, { active: false });
+      }
       this.app.workspace.revealLeaf(leaf);
       return leaf;
     } catch (err) {
@@ -281,6 +289,16 @@ export default class QmdAsMdPlugin extends Plugin {
       let previewUrl: string | null = null;
       let pdfPreviewLeaf: WorkspaceLeaf | null = null;
       let pdfPreviewPath: string | null = null;
+      // Serialize calls to openOrRefreshPdfPreview. Quarto preview emits
+      // "Output created: foo.pdf" on every recompile, sometimes several
+      // times in quick succession; without serialization each in-flight
+      // call hits getLeaf('split', 'vertical') before the previous one
+      // updates pdfPreviewLeaf, opening multiple stacked tabs. If the
+      // user also has Obsidian's "When splitting, duplicate current
+      // note" preference on, those fresh splits briefly show the
+      // currently-edited .qmd before our openFile resolves — which is
+      // what the user reported.
+      let pdfPreviewChain: Promise<void> = Promise.resolve();
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
       // not strictly content/error, so log by line prefix instead of
@@ -305,9 +323,12 @@ export default class QmdAsMdPlugin extends Plugin {
             const sourceDir = file.parent?.path ?? '';
             const vaultPath = sourceDir ? `${sourceDir}/${outBasename}` : outBasename;
             pdfPreviewPath = vaultPath;
-            // Fire-and-forget; errors logged inside.
-            this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf).then((leaf) => {
-              pdfPreviewLeaf = leaf ?? pdfPreviewLeaf;
+            // Append to the chain so calls run strictly in order; the
+            // captured leaf ref is read fresh at the moment each call
+            // actually starts, not when the line arrived.
+            pdfPreviewChain = pdfPreviewChain.then(async () => {
+              const leaf = await this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf);
+              if (leaf) pdfPreviewLeaf = leaf;
             });
             continue;
           }


### PR DESCRIPTION
## Symptom

After saving the `.qmd`, **3+ tabs opened showing the `.qmd` source itself** (not the rendered PDF) on every save.

## Cause

Two compounding race factors:

1. `quarto preview` emits `Output created: foo.pdf` multiple times in quick succession after each save (initial compile, plus per-target). The previous code fired-and-forgot a call to `openOrRefreshPdfPreview` per line. While call #1 was still awaiting `waitForVaultFile` / `openFile`, calls #2..N all read `pdfPreviewLeaf` as `null` and each hit `getLeaf('split', 'vertical')` — stacking new splits.
2. Obsidian has a preference, **"When splitting, duplicate current note"** (in Editor settings on some users' setups). When on, fresh splits inherit the active leaf's content briefly. Each of those new splits therefore showed the `.qmd` source until our `openFile(pdfTFile)` resolved — which never reliably happened for all of them.

Net effect: N concurrent splits, all initially showing the `.qmd` clone, and most never being reopened with the PDF.

## Fix

- **Serialize** `openOrRefreshPdfPreview` calls via a `pdfPreviewChain` Promise. Each detected `Output created:` line awaits the previous call before starting, so `pdfPreviewLeaf` is up-to-date when `getLeaf` would otherwise be reached. Only the first call creates a split; the rest reuse it.
- **Skip the no-op reopen.** Inside `openOrRefreshPdfPreview`, if the reused leaf already shows the target file, do not call `openFile` again. Obsidian's PDF viewer reloads on file mtime change on its own; the explicit reopen only triggered a focus/reveal shuffle.

## Test plan

- [ ] Run **Toggle Quarto Preview** on a `format: typst` doc. Native PDF tab opens. Save the source repeatedly — same tab refreshes; no new tabs.
- [ ] Same as above with **"When splitting, duplicate current note"** enabled in Obsidian settings — still only one PDF tab; no stray `.qmd` duplicates.
- [ ] Run on a `format: html` doc. Webviewer tab opens once; saves do not stack additional tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Serialize PDF preview leaf updates to prevent duplicate tabs when saving and avoid unnecessary PDF reopen operations.

Bug Fixes:
- Prevent multiple PDF preview tabs from opening when Quarto emits repeated 'Output created' events on save.
- Avoid focus/reveal shuffling by skipping redundant reopen of an already-open PDF file in the preview leaf.