### PR TITLE
fix(preview): open PDF once per session, stop reacting to every recompile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -287,18 +287,16 @@ export default class QmdAsMdPlugin extends Plugin {
       );
 
       let previewUrl: string | null = null;
-      let pdfPreviewLeaf: WorkspaceLeaf | null = null;
       let pdfPreviewPath: string | null = null;
-      // Serialize calls to openOrRefreshPdfPreview. Quarto preview emits
-      // "Output created: foo.pdf" on every recompile, sometimes several
-      // times in quick succession; without serialization each in-flight
-      // call hits getLeaf('split', 'vertical') before the previous one
-      // updates pdfPreviewLeaf, opening multiple stacked tabs. If the
-      // user also has Obsidian's "When splitting, duplicate current
-      // note" preference on, those fresh splits briefly show the
-      // currently-edited .qmd before our openFile resolves — which is
-      // what the user reported.
-      let pdfPreviewChain: Promise<void> = Promise.resolve();
+      // Open the PDF tab once per preview session. Quarto preview emits
+      // "Output created: foo.pdf" on every recompile (and sometimes
+      // multiple times per recompile). Reacting to every emission
+      // caused stacked tabs; serializing helped but did not fully
+      // prevent it under Obsidian's "When splitting, duplicate current
+      // note" preference. Obsidian's PDF viewer reloads on file mtime
+      // change on its own, so we only need to open the leaf the first
+      // time and let Obsidian's watcher handle live reload thereafter.
+      let pdfPreviewOpened = false;
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
       // not strictly content/error, so log by line prefix instead of
@@ -323,13 +321,16 @@ export default class QmdAsMdPlugin extends Plugin {
             const sourceDir = file.parent?.path ?? '';
             const vaultPath = sourceDir ? `${sourceDir}/${outBasename}` : outBasename;
             pdfPreviewPath = vaultPath;
-            // Append to the chain so calls run strictly in order; the
-            // captured leaf ref is read fresh at the moment each call
-            // actually starts, not when the line arrived.
-            pdfPreviewChain = pdfPreviewChain.then(async () => {
-              const leaf = await this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf);
-              if (leaf) pdfPreviewLeaf = leaf;
-            });
+            if (!pdfPreviewOpened) {
+              pdfPreviewOpened = true;
+              // Fire-and-forget; openOrRefreshPdfPreview's lookup will
+              // reuse any pre-existing PDF leaf showing this file.
+              this.openOrRefreshPdfPreview(vaultPath, null).catch((err) => {
+                console.error('[qmd-as-md] PDF preview open failed:', err);
+                // Allow a retry on the next compile if this one threw.
+                pdfPreviewOpened = false;
+              });
+            }
             continue;
           }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,16 +287,23 @@ export default class QmdAsMdPlugin extends Plugin {
       );
 
       let previewUrl: string | null = null;
-      let pdfPreviewPath: string | null = null;
-      // Open the PDF tab once per preview session. Quarto preview emits
+      // Track the open PDF leaf, the path it shows, and whether a call
+      // to openOrRefreshPdfPreview is in flight. Quarto preview emits
       // "Output created: foo.pdf" on every recompile (and sometimes
-      // multiple times per recompile). Reacting to every emission
-      // caused stacked tabs; serializing helped but did not fully
-      // prevent it under Obsidian's "When splitting, duplicate current
-      // note" preference. Obsidian's PDF viewer reloads on file mtime
-      // change on its own, so we only need to open the leaf the first
-      // time and let Obsidian's watcher handle live reload thereafter.
-      let pdfPreviewOpened = false;
+      // multiple times per recompile), so the handler runs frequently:
+      //
+      //  - If the leaf is still attached and showing the same path, do
+      //    nothing — Obsidian's PDF viewer reloads on file mtime change
+      //    on its own, no plugin action needed.
+      //  - If the user closed the leaf, or Quarto switched output paths
+      //    (multi-format projects), allow the helper to (re)open.
+      //  - The busy flag dedups concurrent calls so a burst of emissions
+      //    never opens more than one tab; if a save races in while the
+      //    first call is awaiting waitForVaultFile / openFile, the
+      //    second emission is dropped.
+      let pdfPreviewLeaf: WorkspaceLeaf | null = null;
+      let pdfPreviewPath: string | null = null;
+      let pdfPreviewBusy = false;
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
       // not strictly content/error, so log by line prefix instead of
@@ -320,17 +327,31 @@ export default class QmdAsMdPlugin extends Plugin {
             const outBasename = path.basename(outMatch[1].trim());
             const sourceDir = file.parent?.path ?? '';
             const vaultPath = sourceDir ? `${sourceDir}/${outBasename}` : outBasename;
-            pdfPreviewPath = vaultPath;
-            if (!pdfPreviewOpened) {
-              pdfPreviewOpened = true;
-              // Fire-and-forget; openOrRefreshPdfPreview's lookup will
-              // reuse any pre-existing PDF leaf showing this file.
-              this.openOrRefreshPdfPreview(vaultPath, null).catch((err) => {
-                console.error('[qmd-as-md] PDF preview open failed:', err);
-                // Allow a retry on the next compile if this one threw.
-                pdfPreviewOpened = false;
-              });
+
+            const leafAttached = pdfPreviewLeaf?.parent != null;
+            const pathSame = pdfPreviewPath === vaultPath;
+            if (pdfPreviewBusy || (leafAttached && pathSame)) {
+              // Already shown, mtime watcher will refresh; or a previous
+              // call is still resolving and will land on this same path.
+              pdfPreviewPath = vaultPath;
+              continue;
             }
+
+            pdfPreviewBusy = true;
+            pdfPreviewPath = vaultPath;
+            this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf)
+              .then((leaf) => {
+                if (leaf) pdfPreviewLeaf = leaf;
+              })
+              .catch((err) => {
+                console.error('[qmd-as-md] PDF preview open failed:', err);
+                // Clear state so the next emission can retry cleanly.
+                pdfPreviewLeaf = null;
+                pdfPreviewPath = null;
+              })
+              .finally(() => {
+                pdfPreviewBusy = false;
+              });
             continue;
           }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -331,9 +331,12 @@ export default class QmdAsMdPlugin extends Plugin {
             const leafAttached = pdfPreviewLeaf?.parent != null;
             const pathSame = pdfPreviewPath === vaultPath;
             if (pdfPreviewBusy || (leafAttached && pathSame)) {
-              // Already shown, mtime watcher will refresh; or a previous
-              // call is still resolving and will land on this same path.
-              pdfPreviewPath = vaultPath;
+              // Either a previous open is still resolving (its path was
+              // recorded synchronously when it was scheduled — don't
+              // clobber it here for a different vaultPath, or the
+              // tracked state could desync from what the leaf actually
+              // shows), or the leaf is already on this path and
+              // Obsidian's mtime watcher will refresh it.
               continue;
             }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -288,30 +288,37 @@ export default class QmdAsMdPlugin extends Plugin {
 
       let previewUrl: string | null = null;
 
-      // PDF-preview tab is opened once per preview session. Quarto
-      // emits "Output created: foo.pdf" on every recompile (often
-      // several times per recompile); we ignore those after the
-      // first because Obsidian's PDF viewer reloads on file mtime
-      // change on its own.
+      // PDF-preview state. Quarto emits "Output created: foo.pdf" on
+      // every recompile (often several times per recompile); the
+      // handler dedups so we don't spawn tabs on every save.
       //
-      // We do allow one re-open if the user manually closed the tab
-      // mid-session — checked via leaf.parent. The busy flag
-      // prevents a burst of emissions from racing into multiple
-      // open calls before the first resolves.
+      //  leaf:  current PDF tab, if any.
+      //  path:  the path that leaf is showing (and the path of an
+      //         in-flight open call, recorded synchronously when it
+      //         is scheduled). Also gates the webviewer-URL skip
+      //         logic on the "Browse at" branch below — when a PDF
+      //         preview is active, we don't open Quarto's PDF.js
+      //         wrapper page in the webviewer too.
+      //  busy:  a call to openOrRefreshPdfPreview is in flight.
       //
-      // Trade-off: if Quarto switches output paths mid-session (e.g.
-      // a multi-format project producing both pdf and another format
-      // alternately), the leaf will stay on the first PDF path. Toggle
-      // the preview off+on to pick up the new path. The earlier
-      // pending-queue version handled this automatically but added
-      // state-machine complexity for a rare case.
+      // Schedule open when any of:
+      //   - leaf is detached (user closed the tab manually)
+      //   - the new output path differs from the tracked one
+      //     (multi-format project, or rename)
+      //   - we never opened in this session
+      // Skip when busy (bursts of emissions during recompile dedup
+      // automatically; the final emission of a burst wins because it
+      // arrives after busy clears).
       let pdfPreviewLeaf: WorkspaceLeaf | null = null;
       let pdfPreviewPath: string | null = null;
       let pdfPreviewBusy = false;
 
       const schedulePdfPreview = (vaultPath: string): void => {
         if (pdfPreviewBusy) return;
-        if (pdfPreviewLeaf?.parent != null) return; // already attached
+        const leafAttached = pdfPreviewLeaf?.parent != null;
+        const pathSame = pdfPreviewPath === vaultPath;
+        if (leafAttached && pathSame) return;
+
         pdfPreviewBusy = true;
         pdfPreviewPath = vaultPath;
         this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf)
@@ -320,7 +327,6 @@ export default class QmdAsMdPlugin extends Plugin {
           })
           .catch((err) => {
             console.error('[qmd-as-md] PDF preview open failed:', err);
-            // Clear so the next emission can retry cleanly.
             pdfPreviewLeaf = null;
             pdfPreviewPath = null;
           })

--- a/src/main.ts
+++ b/src/main.ts
@@ -288,48 +288,30 @@ export default class QmdAsMdPlugin extends Plugin {
 
       let previewUrl: string | null = null;
 
-      // PDF-preview state machine. Encapsulated in a closure so the
-      // semantics live in one place instead of being smeared across
-      // the log-line handler.
+      // PDF-preview tab is opened once per preview session. Quarto
+      // emits "Output created: foo.pdf" on every recompile (often
+      // several times per recompile); we ignore those after the
+      // first because Obsidian's PDF viewer reloads on file mtime
+      // change on its own.
       //
-      //  leaf:    the WorkspaceLeaf showing the current PDF, if any.
-      //  path:    the vault-relative path that leaf is showing; also
-      //           the path of an in-flight open call, recorded
-      //           synchronously when it is scheduled.
-      //  busy:    a call to openOrRefreshPdfPreview is in flight.
-      //  pending: a different path that arrived while busy, queued so
-      //           the most-recent emission wins when busy clears.
+      // We do allow one re-open if the user manually closed the tab
+      // mid-session — checked via leaf.parent. The busy flag
+      // prevents a burst of emissions from racing into multiple
+      // open calls before the first resolves.
       //
-      // Quarto preview emits "Output created: foo.pdf" on every
-      // recompile (sometimes several times per recompile), so the
-      // handler runs frequently and needs strict deduplication:
-      //
-      //  - leaf attached, path matches  -> no-op; Obsidian's PDF
-      //    viewer reloads on file mtime change on its own.
-      //  - busy, path matches the in-flight one -> no-op (it will
-      //    land on the right file shortly).
-      //  - busy, path differs -> record as pending; resolved call
-      //    drains the latest pending into a fresh schedule.
-      //  - otherwise -> schedule a fresh open/refresh.
+      // Trade-off: if Quarto switches output paths mid-session (e.g.
+      // a multi-format project producing both pdf and another format
+      // alternately), the leaf will stay on the first PDF path. Toggle
+      // the preview off+on to pick up the new path. The earlier
+      // pending-queue version handled this automatically but added
+      // state-machine complexity for a rare case.
       let pdfPreviewLeaf: WorkspaceLeaf | null = null;
       let pdfPreviewPath: string | null = null;
       let pdfPreviewBusy = false;
-      let pdfPreviewPending: string | null = null;
 
       const schedulePdfPreview = (vaultPath: string): void => {
-        const leafAttached = pdfPreviewLeaf?.parent != null;
-        const pathSame = pdfPreviewPath === vaultPath;
-
-        if (pdfPreviewBusy) {
-          // Don't clobber the in-flight call's recorded path; only
-          // queue a divergent path so the latest output wins after
-          // busy clears.
-          if (!pathSame) pdfPreviewPending = vaultPath;
-          return;
-        }
-
-        if (leafAttached && pathSame) return; // mtime watcher refreshes it
-
+        if (pdfPreviewBusy) return;
+        if (pdfPreviewLeaf?.parent != null) return; // already attached
         pdfPreviewBusy = true;
         pdfPreviewPath = vaultPath;
         this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf)
@@ -344,14 +326,6 @@ export default class QmdAsMdPlugin extends Plugin {
           })
           .finally(() => {
             pdfPreviewBusy = false;
-            // Drain a queued path-change that arrived while busy.
-            if (pdfPreviewPending && pdfPreviewPending !== pdfPreviewPath) {
-              const next = pdfPreviewPending;
-              pdfPreviewPending = null;
-              schedulePdfPreview(next);
-            } else {
-              pdfPreviewPending = null;
-            }
           });
       };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,23 +287,73 @@ export default class QmdAsMdPlugin extends Plugin {
       );
 
       let previewUrl: string | null = null;
-      // Track the open PDF leaf, the path it shows, and whether a call
-      // to openOrRefreshPdfPreview is in flight. Quarto preview emits
-      // "Output created: foo.pdf" on every recompile (and sometimes
-      // multiple times per recompile), so the handler runs frequently:
+
+      // PDF-preview state machine. Encapsulated in a closure so the
+      // semantics live in one place instead of being smeared across
+      // the log-line handler.
       //
-      //  - If the leaf is still attached and showing the same path, do
-      //    nothing — Obsidian's PDF viewer reloads on file mtime change
-      //    on its own, no plugin action needed.
-      //  - If the user closed the leaf, or Quarto switched output paths
-      //    (multi-format projects), allow the helper to (re)open.
-      //  - The busy flag dedups concurrent calls so a burst of emissions
-      //    never opens more than one tab; if a save races in while the
-      //    first call is awaiting waitForVaultFile / openFile, the
-      //    second emission is dropped.
+      //  leaf:    the WorkspaceLeaf showing the current PDF, if any.
+      //  path:    the vault-relative path that leaf is showing; also
+      //           the path of an in-flight open call, recorded
+      //           synchronously when it is scheduled.
+      //  busy:    a call to openOrRefreshPdfPreview is in flight.
+      //  pending: a different path that arrived while busy, queued so
+      //           the most-recent emission wins when busy clears.
+      //
+      // Quarto preview emits "Output created: foo.pdf" on every
+      // recompile (sometimes several times per recompile), so the
+      // handler runs frequently and needs strict deduplication:
+      //
+      //  - leaf attached, path matches  -> no-op; Obsidian's PDF
+      //    viewer reloads on file mtime change on its own.
+      //  - busy, path matches the in-flight one -> no-op (it will
+      //    land on the right file shortly).
+      //  - busy, path differs -> record as pending; resolved call
+      //    drains the latest pending into a fresh schedule.
+      //  - otherwise -> schedule a fresh open/refresh.
       let pdfPreviewLeaf: WorkspaceLeaf | null = null;
       let pdfPreviewPath: string | null = null;
       let pdfPreviewBusy = false;
+      let pdfPreviewPending: string | null = null;
+
+      const schedulePdfPreview = (vaultPath: string): void => {
+        const leafAttached = pdfPreviewLeaf?.parent != null;
+        const pathSame = pdfPreviewPath === vaultPath;
+
+        if (pdfPreviewBusy) {
+          // Don't clobber the in-flight call's recorded path; only
+          // queue a divergent path so the latest output wins after
+          // busy clears.
+          if (!pathSame) pdfPreviewPending = vaultPath;
+          return;
+        }
+
+        if (leafAttached && pathSame) return; // mtime watcher refreshes it
+
+        pdfPreviewBusy = true;
+        pdfPreviewPath = vaultPath;
+        this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf)
+          .then((leaf) => {
+            if (leaf) pdfPreviewLeaf = leaf;
+          })
+          .catch((err) => {
+            console.error('[qmd-as-md] PDF preview open failed:', err);
+            // Clear so the next emission can retry cleanly.
+            pdfPreviewLeaf = null;
+            pdfPreviewPath = null;
+          })
+          .finally(() => {
+            pdfPreviewBusy = false;
+            // Drain a queued path-change that arrived while busy.
+            if (pdfPreviewPending && pdfPreviewPending !== pdfPreviewPath) {
+              const next = pdfPreviewPending;
+              pdfPreviewPending = null;
+              schedulePdfPreview(next);
+            } else {
+              pdfPreviewPending = null;
+            }
+          });
+      };
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
       // not strictly content/error, so log by line prefix instead of
@@ -327,34 +377,7 @@ export default class QmdAsMdPlugin extends Plugin {
             const outBasename = path.basename(outMatch[1].trim());
             const sourceDir = file.parent?.path ?? '';
             const vaultPath = sourceDir ? `${sourceDir}/${outBasename}` : outBasename;
-
-            const leafAttached = pdfPreviewLeaf?.parent != null;
-            const pathSame = pdfPreviewPath === vaultPath;
-            if (pdfPreviewBusy || (leafAttached && pathSame)) {
-              // Either a previous open is still resolving (its path was
-              // recorded synchronously when it was scheduled — don't
-              // clobber it here for a different vaultPath, or the
-              // tracked state could desync from what the leaf actually
-              // shows), or the leaf is already on this path and
-              // Obsidian's mtime watcher will refresh it.
-              continue;
-            }
-
-            pdfPreviewBusy = true;
-            pdfPreviewPath = vaultPath;
-            this.openOrRefreshPdfPreview(vaultPath, pdfPreviewLeaf)
-              .then((leaf) => {
-                if (leaf) pdfPreviewLeaf = leaf;
-              })
-              .catch((err) => {
-                console.error('[qmd-as-md] PDF preview open failed:', err);
-                // Clear state so the next emission can retry cleanly.
-                pdfPreviewLeaf = null;
-                pdfPreviewPath = null;
-              })
-              .finally(() => {
-                pdfPreviewBusy = false;
-              });
+            schedulePdfPreview(vaultPath);
             continue;
           }
 


### PR DESCRIPTION
## Symptom (persisted after PR #15)

User still reported 3+ tabs of the `.qmd` source opening on every save of the active document during a `quarto preview` session.

## Why PR #15 was not enough

PR #15 serialized the calls to `openOrRefreshPdfPreview` via a Promise chain. Calls no longer raced — but each call still:

1. Hit `getLeaf('split', 'vertical')` on first invocation; under Obsidian's **"When splitting, duplicate current note"** preference, the freshly created split is briefly populated with the active leaf's file (the `.qmd`).
2. Awaited `openFile(pdfTFile)` to overwrite that with the PDF.

The serialization eliminated parallel splits, but if the helper was invoked more than once across the session for any reason — e.g. the first call returned early on a transient `waitForVaultFile` timeout while Quarto was still rewriting the file — each subsequent emission triggered another split, each briefly showing the `.qmd`.

## Fix

Open the PDF tab **exactly once per preview session**. Subsequent `Output created: foo.pdf` lines are ignored. Obsidian's PDF viewer reloads on file mtime change without our help, so we do not need to re-invoke `openFile` on every recompile.

- Replaced the Promise chain with a `pdfPreviewOpened` boolean flag.
- First emission per preview session: set the flag, fire `openOrRefreshPdfPreview(vaultPath, null)`. If it throws, reset the flag so the next compile retries.
- Subsequent emissions: noop.
- The helper's internal `getLeavesOfType('pdf')` lookup still reuses a pre-existing PDF leaf for the same file (e.g. one opened earlier by a render command).

## Test plan

- [ ] Toggle Quarto Preview on a `format: typst` doc → one PDF tab opens.
- [ ] Edit and save the source 10+ times → still exactly one PDF tab; PDF content reflects latest save.
- [ ] Enable Obsidian's **"When splitting, duplicate current note"** preference, repeat — still one PDF tab, no `.qmd` duplicates.
- [ ] Close the PDF tab manually, save the source → no auto-reopen (one-shot per session). Toggle the preview off+on to reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deduplicate Quarto PDF preview openings so that only one PDF tab is opened and reused per preview session instead of spawning new tabs on every recompilation.

Bug Fixes:
- Prevent multiple PDF tabs from being opened when Quarto emits repeated 'Output created' messages during a single preview session.
- Ensure PDF preview reopening is skipped while an open operation is already in flight, avoiding transient duplicate tabs and race conditions.