### PR TITLE
fix: surface spawn failures and dump full Quarto output on render error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -365,6 +365,18 @@ export default class QmdAsMdPlugin extends Plugin {
       quartoProcess.stdout?.on('data', (data: Buffer) => handlePreviewOutput(data.toString()));
       quartoProcess.stderr?.on('data', (data: Buffer) => handlePreviewOutput(data.toString()));
 
+      // child_process.spawn does not throw on a missing binary; it emits
+      // an 'error' event later. Without this listener an ENOENT just
+      // produced a silent "exit 1" close with no output to console.
+      quartoProcess.on('error', (err) => {
+        console.error('[qmd-as-md] Failed to spawn quarto for preview:', err);
+        new Notice(
+          `Failed to spawn '${this.settings.quartoPath}': ${err.message}. ` +
+            'Check the Quarto path setting and that Quarto is on PATH.'
+        );
+        this.activePreviewProcesses.delete(file.path);
+      });
+
       quartoProcess.on('close', (code: number | null) => {
         if (code !== null && code !== 0) {
           new Notice(`Quarto preview process exited with code ${code}`);
@@ -440,6 +452,12 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       let detectedOutputBasename: string | null = null;
+      // Capture every line so the close handler can dump them on
+      // non-zero exit, even when emitCompilationLogs is off. Without
+      // this, a failed render only printed lines prefixed with
+      // "ERROR:" — fine when Quarto prefixes its errors, useless
+      // when typst/pandoc surface their own diagnostics.
+      const capturedLines: string[] = [];
 
       // Quarto prints progress to BOTH stdout and stderr. Most of stderr
       // is informational (typst progress, "Output created:", DONE, etc.)
@@ -449,6 +467,7 @@ export default class QmdAsMdPlugin extends Plugin {
       const handleQuartoOutput = (chunk: string) => {
         for (const line of chunk.split(/\r?\n/)) {
           if (!line) continue;
+          capturedLines.push(line);
           if (/^ERROR:/.test(line)) {
             console.error(`Quarto: ${line}`);
           } else if (this.settings.emitCompilationLogs) {
@@ -464,8 +483,25 @@ export default class QmdAsMdPlugin extends Plugin {
       quartoProcess.stdout?.on('data', (data: Buffer) => handleQuartoOutput(data.toString()));
       quartoProcess.stderr?.on('data', (data: Buffer) => handleQuartoOutput(data.toString()));
 
+      // child_process.spawn does not throw on a missing binary; it emits
+      // an 'error' event later. Without this listener an ENOENT just
+      // produced a silent "exit 1" close with no output to console.
+      quartoProcess.on('error', (err) => {
+        console.error('[qmd-as-md] Failed to spawn quarto for render:', err);
+        new Notice(
+          `Failed to spawn '${this.settings.quartoPath}': ${err.message}. ` +
+            'Check the Quarto path setting and that Quarto is on PATH.'
+        );
+      });
+
       quartoProcess.on('close', async (code: number | null) => {
         if (code !== 0) {
+          // Dump every captured line regardless of emitCompilationLogs
+          // so the user has something to read in the console.
+          console.error(
+            `[qmd-as-md] Quarto render failed (exit ${code}). Full output:\n` +
+              capturedLines.join('\n')
+          );
           new Notice(`Quarto render failed (exit ${code}). Check console.`);
           return;
         }


### PR DESCRIPTION
## Why

Follow-up to #17. User reported a render error with **no console output** — the `Quarto render failed` notice fired, but the console was empty, so they had no way to see what Quarto/typst actually said. This regression surfaced after #17 (the Obsidian-guidelines batch A) because that PR stripped the chatty `console.log` breadcrumbs from `onload` / `startPreview` / `renderPdf` (`"Plugin is loading..."`, `"Resolved file path:..."`, `"QUARTO_TYPST set to:..."`, etc.). Those logs never reported spawn failures, but they gave users *something* to read in the console; with them gone, two latent bugs became user-visible:

1. **Silent spawn failures.** `child_process.spawn` does not throw when the command is missing or unauthorised — it emits an `'error'` event later. The plugin was not listening (never has been), so an `ENOENT` for `quarto` (not on the `PATH` Obsidian's renderer inherits) produced a silent `exit 1` close with empty stdout/stderr. Pre-#17 the lifecycle logs masked the absence; post-#17 the console is genuinely empty.
2. **`emitCompilationLogs` gating real-error output.** Quarto wraps its own diagnostics with an `ERROR:` prefix and those were always logged via `console.error`. But typst and pandoc surface diagnostics with other prefixes that were gated behind `emitCompilationLogs`. On a failure the user shouldn't have to toggle a setting to see what went wrong.

## Fixes

- Added `quartoProcess.on('error', …)` on **both** spawn sites (preview and render). The handler logs the underlying error and surfaces a Notice that names the Quarto-path setting so the user can fix it directly.
- During render, every Quarto line is buffered into `capturedLines`. On non-zero exit, the close handler dumps the full buffer to `console.error` regardless of the `emitCompilationLogs` toggle. Successful renders still respect the setting.

## Test plan

- [ ] Set Quarto path to something invalid (e.g. `quartoNOPE`). Run any render command. Confirm a Notice naming the path and an error in console.
- [ ] Render a `.qmd` with a deliberate Typst error (or LaTeX error). Confirm the full Quarto/typst output dumps to console even with **Emit compilation logs** off.
- [ ] Confirm successful renders with **Emit compilation logs** off still produce no console noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)