### PR TITLE
fix: always log Quarto output; drop emitCompilationLogs gate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,14 +22,16 @@ import * as path from 'path';
 // trailing partial line and only emits whole lines. Call .flush() on the
 // close handler to release any final partial line.
 //
-// logQuartoLine routes a single line to console: lines prefixed with
-// "ERROR:" go through console.error so they stand out; everything else
-// goes through console.log so the user can always see what Quarto is
-// doing.
+// logQuartoLine routes a single line to console by severity prefix:
+// "ERROR:" -> console.error, "WARNING:"/"WARN:" -> console.warn,
+// everything else -> console.log. Centralised so both the preview and
+// render paths stay in sync and new prefixes only need handling here.
 
 function logQuartoLine(prefix: string, line: string): void {
   if (/^ERROR:/.test(line)) {
     console.error(`${prefix}: ${line}`);
+  } else if (/^WARN(ING)?:/.test(line)) {
+    console.warn(`${prefix}: ${line}`);
   } else {
     console.log(`${prefix}: ${line}`);
   }
@@ -400,12 +402,13 @@ export default class QmdAsMdPlugin extends Plugin {
         }
       };
 
-      // Quarto's stdout/stderr split is not strictly content/error and
-      // chunk boundaries don't align with line boundaries, so feed both
-      // streams through one buffered line processor.
-      const processPreviewOutput = makeLineProcessor(handlePreviewLine);
-      quartoProcess.stdout?.on('data', (data: Buffer) => processPreviewOutput(data.toString()));
-      quartoProcess.stderr?.on('data', (data: Buffer) => processPreviewOutput(data.toString()));
+      // One buffered processor per stream — stdout and stderr each
+      // need their own partial-line buffer, or interleaved fragments
+      // from the two streams would be spliced into synthetic lines.
+      const previewStdout = makeLineProcessor(handlePreviewLine);
+      const previewStderr = makeLineProcessor(handlePreviewLine);
+      quartoProcess.stdout?.on('data', (data: Buffer) => previewStdout(data.toString()));
+      quartoProcess.stderr?.on('data', (data: Buffer) => previewStderr(data.toString()));
 
       // child_process.spawn does not throw on a missing binary; it emits
       // an 'error' event later. Without this listener an ENOENT just
@@ -420,7 +423,8 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       quartoProcess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
-        processPreviewOutput.flush(); // release any final partial line
+        previewStdout.flush(); // release any final partial line
+        previewStderr.flush();
         if (code !== null && code !== 0) {
           new Notice(`Quarto preview process exited with code ${code}`);
         } else if (code === null && signal && signal !== 'SIGTERM' && signal !== 'SIGKILL') {
@@ -508,12 +512,13 @@ export default class QmdAsMdPlugin extends Plugin {
         }
       };
 
-      // Quarto prints progress to BOTH stdout and stderr, and chunk
-      // boundaries don't align with line boundaries, so feed both
-      // streams through one buffered line processor.
-      const processRenderOutput = makeLineProcessor(handleRenderLine);
-      quartoProcess.stdout?.on('data', (data: Buffer) => processRenderOutput(data.toString()));
-      quartoProcess.stderr?.on('data', (data: Buffer) => processRenderOutput(data.toString()));
+      // One buffered processor per stream — stdout and stderr each
+      // need their own partial-line buffer, or interleaved fragments
+      // from the two streams would be spliced into synthetic lines.
+      const renderStdout = makeLineProcessor(handleRenderLine);
+      const renderStderr = makeLineProcessor(handleRenderLine);
+      quartoProcess.stdout?.on('data', (data: Buffer) => renderStdout(data.toString()));
+      quartoProcess.stderr?.on('data', (data: Buffer) => renderStderr(data.toString()));
 
       // child_process.spawn does not throw on a missing binary; it emits
       // an 'error' event later. Without this listener an ENOENT just
@@ -527,8 +532,19 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       quartoProcess.on('close', async (code: number | null, signal: NodeJS.Signals | null) => {
-        processRenderOutput.flush(); // release any final partial line
-        if (code !== 0) {
+        renderStdout.flush(); // release any final partial line
+        renderStderr.flush();
+
+        // A clean exit is code 0. Anything else is a failure, except a
+        // termination by SIGTERM/SIGKILL — that means the process was
+        // intentionally cancelled (matching the preview handler, which
+        // suppresses notices for those signals). Stay quiet then.
+        if (code === 0) {
+          // fall through to the success path below
+        } else if (code === null && (signal === 'SIGTERM' || signal === 'SIGKILL')) {
+          console.error(`[qmd-as-md] Quarto render cancelled (${signal}).`);
+          return;
+        } else {
           const exitLabel = code !== null
             ? `exit ${code}`
             : signal

--- a/src/main.ts
+++ b/src/main.ts
@@ -377,9 +377,12 @@ export default class QmdAsMdPlugin extends Plugin {
         this.activePreviewProcesses.delete(file.path);
       });
 
-      quartoProcess.on('close', (code: number | null) => {
+      quartoProcess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
         if (code !== null && code !== 0) {
           new Notice(`Quarto preview process exited with code ${code}`);
+        } else if (code === null && signal && signal !== 'SIGTERM' && signal !== 'SIGKILL') {
+          // SIGTERM/SIGKILL come from our own stopPreview / onunload — silent.
+          new Notice(`Quarto preview process was terminated by ${signal}`);
         }
         this.activePreviewProcesses.delete(file.path);
       });
@@ -452,12 +455,13 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       let detectedOutputBasename: string | null = null;
-      // Capture every line so the close handler can dump them on
-      // non-zero exit, even when emitCompilationLogs is off. Without
-      // this, a failed render only printed lines prefixed with
-      // "ERROR:" — fine when Quarto prefixes its errors, useless
-      // when typst/pandoc surface their own diagnostics.
+      // Capture lines for the failure dump below. Bounded — a verbose
+      // render can produce thousands of lines and we only need recent
+      // context to diagnose a failure. Oldest lines are dropped first;
+      // if any were dropped, the dump notes that the prefix is missing.
+      const MAX_CAPTURED_LINES = 1000;
       const capturedLines: string[] = [];
+      let droppedLineCount = 0;
 
       // Quarto prints progress to BOTH stdout and stderr. Most of stderr
       // is informational (typst progress, "Output created:", DONE, etc.)
@@ -468,6 +472,10 @@ export default class QmdAsMdPlugin extends Plugin {
         for (const line of chunk.split(/\r?\n/)) {
           if (!line) continue;
           capturedLines.push(line);
+          if (capturedLines.length > MAX_CAPTURED_LINES) {
+            capturedLines.shift();
+            droppedLineCount++;
+          }
           if (/^ERROR:/.test(line)) {
             console.error(`Quarto: ${line}`);
           } else if (this.settings.emitCompilationLogs) {
@@ -494,15 +502,29 @@ export default class QmdAsMdPlugin extends Plugin {
         );
       });
 
-      quartoProcess.on('close', async (code: number | null) => {
+      quartoProcess.on('close', async (code: number | null, signal: NodeJS.Signals | null) => {
         if (code !== 0) {
-          // Dump every captured line regardless of emitCompilationLogs
-          // so the user has something to read in the console.
-          console.error(
-            `[qmd-as-md] Quarto render failed (exit ${code}). Full output:\n` +
-              capturedLines.join('\n')
-          );
-          new Notice(`Quarto render failed (exit ${code}). Check console.`);
+          const exitLabel = code !== null
+            ? `exit ${code}`
+            : signal
+              ? `terminated by ${signal}`
+              : 'terminated';
+          // Dump captured output when the per-line stream was suppressed
+          // by emitCompilationLogs=false; if it was on, the lines are
+          // already in the console and re-printing them just spams.
+          if (!this.settings.emitCompilationLogs) {
+            const prefix = droppedLineCount > 0
+              ? `… (${droppedLineCount} earlier line(s) dropped)\n`
+              : '';
+            console.error(
+              `[qmd-as-md] Quarto render failed (${exitLabel}). Output:\n` +
+                prefix +
+                capturedLines.join('\n')
+            );
+          } else {
+            console.error(`[qmd-as-md] Quarto render failed (${exitLabel}).`);
+          }
+          new Notice(`Quarto render failed (${exitLabel}). Check console.`);
           return;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ interface QmdPluginSettings {
   quartoPath: string;
   enableQmdLinking: boolean;
   quartoTypst: string;
-  emitCompilationLogs: boolean;
   openPdfInObsidian: boolean;
   previewInObsidian: boolean;
 }
@@ -27,7 +26,6 @@ const DEFAULT_SETTINGS: QmdPluginSettings = {
   quartoPath: 'quarto',
   enableQmdLinking: true,
   quartoTypst: '',
-  emitCompilationLogs: true,
   openPdfInObsidian: false,
   previewInObsidian: true,
 };
@@ -320,14 +318,15 @@ export default class QmdAsMdPlugin extends Plugin {
       };
 
       // Same routing rule as renderPdf: Quarto's stdout/stderr split is
-      // not strictly content/error, so log by line prefix instead of
-      // by stream. Only "ERROR:"-prefixed lines hit console.error.
+      // not strictly content/error, so route by line prefix. Every
+      // line is logged so the user can see what the preview server is
+      // doing; "ERROR:"-prefixed lines go through console.error.
       const handlePreviewOutput = (chunk: string) => {
         for (const line of chunk.split(/\r?\n/)) {
           if (!line) continue;
           if (/^ERROR:/.test(line)) {
             console.error(`Quarto Preview: ${line}`);
-          } else if (this.settings.emitCompilationLogs) {
+          } else {
             console.log(`Quarto Preview: ${line}`);
           }
 
@@ -455,30 +454,18 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       let detectedOutputBasename: string | null = null;
-      // Capture lines for the failure dump below. Bounded — a verbose
-      // render can produce thousands of lines and we only need recent
-      // context to diagnose a failure. Oldest lines are dropped first;
-      // if any were dropped, the dump notes that the prefix is missing.
-      const MAX_CAPTURED_LINES = 1000;
-      const capturedLines: string[] = [];
-      let droppedLineCount = 0;
 
       // Quarto prints progress to BOTH stdout and stderr. Most of stderr
       // is informational (typst progress, "Output created:", DONE, etc.)
-      // Only lines prefixed with "ERROR:" are real errors; logging the
-      // rest via console.error surfaced harmless lines as red error
-      // toasts in Obsidian. Route by content, not by stream.
+      // Route by line prefix: "ERROR:" goes through console.error so
+      // it stands out; everything else goes through console.log so the
+      // user can always see what Quarto is doing.
       const handleQuartoOutput = (chunk: string) => {
         for (const line of chunk.split(/\r?\n/)) {
           if (!line) continue;
-          capturedLines.push(line);
-          if (capturedLines.length > MAX_CAPTURED_LINES) {
-            capturedLines.shift();
-            droppedLineCount++;
-          }
           if (/^ERROR:/.test(line)) {
             console.error(`Quarto: ${line}`);
-          } else if (this.settings.emitCompilationLogs) {
+          } else {
             console.log(`Quarto: ${line}`);
           }
           const match = line.match(/Output created:\s*(.+?)\s*$/);
@@ -509,21 +496,10 @@ export default class QmdAsMdPlugin extends Plugin {
             : signal
               ? `terminated by ${signal}`
               : 'terminated';
-          // Dump captured output when the per-line stream was suppressed
-          // by emitCompilationLogs=false; if it was on, the lines are
-          // already in the console and re-printing them just spams.
-          if (!this.settings.emitCompilationLogs) {
-            const prefix = droppedLineCount > 0
-              ? `… (${droppedLineCount} earlier line(s) dropped)\n`
-              : '';
-            console.error(
-              `[qmd-as-md] Quarto render failed (${exitLabel}). Output:\n` +
-                prefix +
-                capturedLines.join('\n')
-            );
-          } else {
-            console.error(`[qmd-as-md] Quarto render failed (${exitLabel}).`);
-          }
+          // The full output was already streamed line-by-line through
+          // console.log / console.error as it arrived — no need to
+          // re-dump it. Just summarise the failure.
+          console.error(`[qmd-as-md] Quarto render failed (${exitLabel}).`);
           new Notice(`Quarto render failed (${exitLabel}). Check console.`);
           return;
         }
@@ -637,18 +613,6 @@ class QmdSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.quartoTypst)
           .onChange(async (value) => {
             this.plugin.settings.quartoTypst = value;
-            await this.plugin.saveSettings();
-          })
-      );
-
-    new Setting(containerEl)
-      .setName('Emit compilation logs')
-      .setDesc('Print detailed Quarto compilation output to the developer console.')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.emitCompilationLogs)
-          .onChange(async (value) => {
-            this.plugin.settings.emitCompilationLogs = value;
             await this.plugin.saveSettings();
           })
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,54 @@ import {
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
 
+// --- Quarto output plumbing -----------------------------------------------
+//
+// Node's spawn-stream chunks don't align with line boundaries — a single
+// data event can contain a partial line, and a logical line can be split
+// across two events. Build a per-stream processor that buffers the
+// trailing partial line and only emits whole lines. Call .flush() on the
+// close handler to release any final partial line.
+//
+// logQuartoLine routes a single line to console: lines prefixed with
+// "ERROR:" go through console.error so they stand out; everything else
+// goes through console.log so the user can always see what Quarto is
+// doing.
+
+function logQuartoLine(prefix: string, line: string): void {
+  if (/^ERROR:/.test(line)) {
+    console.error(`${prefix}: ${line}`);
+  } else {
+    console.log(`${prefix}: ${line}`);
+  }
+}
+
+interface LineProcessor {
+  (chunk: string): void;
+  flush(): void;
+}
+
+function makeLineProcessor(handle: (line: string) => void): LineProcessor {
+  let buffer = '';
+  const proc = ((chunk: string) => {
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/);
+    // Last element is the trailing fragment after the final newline
+    // (or the whole chunk if there was no newline at all). Keep it
+    // for the next chunk.
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line) handle(line);
+    }
+  }) as LineProcessor;
+  proc.flush = () => {
+    if (buffer) {
+      handle(buffer);
+      buffer = '';
+    }
+  };
+  return proc;
+}
+
 interface QmdPluginSettings {
   quartoPath: string;
   enableQmdLinking: boolean;
@@ -317,52 +365,47 @@ export default class QmdAsMdPlugin extends Plugin {
           });
       };
 
-      // Same routing rule as renderPdf: Quarto's stdout/stderr split is
-      // not strictly content/error, so route by line prefix. Every
-      // line is logged so the user can see what the preview server is
-      // doing; "ERROR:"-prefixed lines go through console.error.
-      const handlePreviewOutput = (chunk: string) => {
-        for (const line of chunk.split(/\r?\n/)) {
-          if (!line) continue;
-          if (/^ERROR:/.test(line)) {
-            console.error(`Quarto Preview: ${line}`);
-          } else {
-            console.log(`Quarto Preview: ${line}`);
-          }
+      // Per-line handler: log the line, then look for the two markers
+      // we care about ("Output created:" and "Browse at").
+      const handlePreviewLine = (line: string) => {
+        logQuartoLine('Quarto Preview', line);
 
-          // Detect "Output created: <path>" — quarto prints this on every
-          // compile in preview mode. If the output is a PDF, route to
-          // Obsidian's native PDF viewer rather than the webviewer page
-          // Quarto serves at /web/viewer.html. Subsequent compiles refresh
-          // the same leaf so live reload still works.
-          const outMatch = line.match(/Output created:\s*(.+?)\s*$/);
-          if (outMatch && /\.pdf$/i.test(outMatch[1].trim()) && this.settings.previewInObsidian) {
-            const outBasename = path.basename(outMatch[1].trim());
-            const sourceDir = file.parent?.path ?? '';
-            const vaultPath = normalizePath(sourceDir ? `${sourceDir}/${outBasename}` : outBasename);
-            schedulePdfPreview(vaultPath);
-            continue;
-          }
+        // Detect "Output created: <path>" — quarto prints this on every
+        // compile in preview mode. If the output is a PDF, route to
+        // Obsidian's native PDF viewer rather than the webviewer page
+        // Quarto serves at /web/viewer.html. Subsequent compiles refresh
+        // the same leaf so live reload still works.
+        const outMatch = line.match(/Output created:\s*(.+?)\s*$/);
+        if (outMatch && /\.pdf$/i.test(outMatch[1].trim()) && this.settings.previewInObsidian) {
+          const outBasename = path.basename(outMatch[1].trim());
+          const sourceDir = file.parent?.path ?? '';
+          const vaultPath = normalizePath(sourceDir ? `${sourceDir}/${outBasename}` : outBasename);
+          schedulePdfPreview(vaultPath);
+          return;
+        }
 
-          if (!previewUrl && line.includes('Browse at')) {
-            const match = line.match(/Browse at\s+(http:\/\/[^\s]+)/);
-            if (match && match[1]) {
-              previewUrl = match[1];
-              // If we already opened a native PDF preview, skip the
-              // webviewer URL — Quarto's PDF.js wrapper would just be
-              // a worse version of the same content.
-              if (pdfPreviewPath) {
-                new Notice(`PDF preview opened natively. Server URL: ${previewUrl}`);
-              } else {
-                this.openPreviewUrl(previewUrl);
-              }
+        if (!previewUrl && line.includes('Browse at')) {
+          const match = line.match(/Browse at\s+(http:\/\/[^\s]+)/);
+          if (match && match[1]) {
+            previewUrl = match[1];
+            // If we already opened a native PDF preview, skip the
+            // webviewer URL — Quarto's PDF.js wrapper would just be
+            // a worse version of the same content.
+            if (pdfPreviewPath) {
+              new Notice(`PDF preview opened natively. Server URL: ${previewUrl}`);
+            } else {
+              this.openPreviewUrl(previewUrl);
             }
           }
         }
       };
 
-      quartoProcess.stdout?.on('data', (data: Buffer) => handlePreviewOutput(data.toString()));
-      quartoProcess.stderr?.on('data', (data: Buffer) => handlePreviewOutput(data.toString()));
+      // Quarto's stdout/stderr split is not strictly content/error and
+      // chunk boundaries don't align with line boundaries, so feed both
+      // streams through one buffered line processor.
+      const processPreviewOutput = makeLineProcessor(handlePreviewLine);
+      quartoProcess.stdout?.on('data', (data: Buffer) => processPreviewOutput(data.toString()));
+      quartoProcess.stderr?.on('data', (data: Buffer) => processPreviewOutput(data.toString()));
 
       // child_process.spawn does not throw on a missing binary; it emits
       // an 'error' event later. Without this listener an ENOENT just
@@ -377,6 +420,7 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       quartoProcess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+        processPreviewOutput.flush(); // release any final partial line
         if (code !== null && code !== 0) {
           new Notice(`Quarto preview process exited with code ${code}`);
         } else if (code === null && signal && signal !== 'SIGTERM' && signal !== 'SIGKILL') {
@@ -455,28 +499,21 @@ export default class QmdAsMdPlugin extends Plugin {
 
       let detectedOutputBasename: string | null = null;
 
-      // Quarto prints progress to BOTH stdout and stderr. Most of stderr
-      // is informational (typst progress, "Output created:", DONE, etc.)
-      // Route by line prefix: "ERROR:" goes through console.error so
-      // it stands out; everything else goes through console.log so the
-      // user can always see what Quarto is doing.
-      const handleQuartoOutput = (chunk: string) => {
-        for (const line of chunk.split(/\r?\n/)) {
-          if (!line) continue;
-          if (/^ERROR:/.test(line)) {
-            console.error(`Quarto: ${line}`);
-          } else {
-            console.log(`Quarto: ${line}`);
-          }
-          const match = line.match(/Output created:\s*(.+?)\s*$/);
-          if (match) {
-            detectedOutputBasename = path.basename(match[1].trim());
-          }
+      // Per-line handler: log the line, then watch for "Output created:".
+      const handleRenderLine = (line: string) => {
+        logQuartoLine('Quarto', line);
+        const match = line.match(/Output created:\s*(.+?)\s*$/);
+        if (match) {
+          detectedOutputBasename = path.basename(match[1].trim());
         }
       };
 
-      quartoProcess.stdout?.on('data', (data: Buffer) => handleQuartoOutput(data.toString()));
-      quartoProcess.stderr?.on('data', (data: Buffer) => handleQuartoOutput(data.toString()));
+      // Quarto prints progress to BOTH stdout and stderr, and chunk
+      // boundaries don't align with line boundaries, so feed both
+      // streams through one buffered line processor.
+      const processRenderOutput = makeLineProcessor(handleRenderLine);
+      quartoProcess.stdout?.on('data', (data: Buffer) => processRenderOutput(data.toString()));
+      quartoProcess.stderr?.on('data', (data: Buffer) => processRenderOutput(data.toString()));
 
       // child_process.spawn does not throw on a missing binary; it emits
       // an 'error' event later. Without this listener an ENOENT just
@@ -490,6 +527,7 @@ export default class QmdAsMdPlugin extends Plugin {
       });
 
       quartoProcess.on('close', async (code: number | null, signal: NodeJS.Signals | null) => {
+        processRenderOutput.flush(); // release any final partial line
         if (code !== 0) {
           const exitLabel = code !== null
             ? `exit ${code}`


### PR DESCRIPTION
## Why

Follow-up to #18. User: *"I want all Quarto output to be emitted via console, otherwise I don't know what is happening."*

`emitCompilationLogs` was a misfeature. Quarto's output is the only window into what is happening during preview/render; gating it behind a setting that defaulted to "on but easy to forget" cost debuggability with no real benefit. Previous PR #18 also introduced bounded-buffer + failure-dump logic to compensate for the gate, which now becomes unnecessary.

## What changed

- **Drop the `emitCompilationLogs` setting**: removed from interface, defaults, and settings tab.
- **Always stream every Quarto line** through `console.log`, with `ERROR:`-prefixed lines routed to `console.error` so they stand out.
- Applied symmetrically to `renderPdf` and `startPreview`.
- **Removed `capturedLines` / `MAX_CAPTURED_LINES` / `droppedLineCount`** in `renderPdf`. Output is already in the console as it arrives — the failure handler now prints a one-line summary only. Net `-48 / +12` lines.

## Behaviour notes

- Existing users with `emitCompilationLogs: false` in `data.json` will simply have that field ignored. `loadSettings` merges via `Object.assign({}, DEFAULT_SETTINGS, await loadData())`, which only carries forward keys present in the new defaults — unknown keys are dropped harmlessly into the in-memory settings object. Behaviour falls back to "always log" automatically.
- No migration required.

## Test plan

- [ ] Run **Toggle Quarto preview** on a healthy `.qmd`. Confirm every Quarto line appears in DevTools console as it arrives.
- [ ] Render with a deliberate Typst/LaTeX error. Confirm the full Quarto output is visible in console, including diagnostics that don't carry the `ERROR:` prefix.
- [ ] Confirm the "Emit compilation logs" toggle is gone from the settings tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Always stream Quarto compilation output to the console and simplify failure handling for both preview and render flows.

Bug Fixes:
- Ensure all Quarto output lines are logged with appropriate severity, improving visibility into preview and render processes.
- Handle Quarto process termination signals consistently for preview and render, avoiding noisy notices for intentional cancellations and summarising unexpected terminations.

Enhancements:
- Introduce a shared line-processing utility to correctly reconstruct and log Quarto output line-by-line from stdout and stderr streams.
- Unify log routing for Quarto preview and render paths via a common severity-based logging helper.
- Simplify render failure reporting by replacing buffered full-output dumps with concise summary messages now that all output is streamed live.

Chores:
- Remove the obsolete `emitCompilationLogs` setting and its UI toggle from the plugin configuration.